### PR TITLE
Fir 9113: better error messages

### DIFF
--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -9,7 +9,7 @@ from httpx import HTTPStatusError, RequestError, Timeout
 
 from firebolt.async_db.cursor import BaseCursor, Cursor
 from firebolt.client import DEFAULT_API_URL, AsyncClient
-from firebolt.common.exception import ConnectionClosedError, InterfaceError
+from firebolt.common.exception import ConnectionClosedError, InterfaceError, FireboltEngineError
 from firebolt.common.urls import ACCOUNT_ENGINE_URL, ENGINE_BY_NAME_URL
 from firebolt.common.util import cached_property, fix_url_schema
 
@@ -39,7 +39,9 @@ async def _resolve_engine_url(
             )
             response.raise_for_status()
             return response.json()["engine"]["endpoint"]
-        except (JSONDecodeError, RequestError, HTTPStatusError, RuntimeError) as e:
+        except HTTPStatusError as e:
+            raise FireboltEngineError(f"Firebolt engine {engine_name} does not exist")
+        except (JSONDecodeError, RequestError, RuntimeError) as e:
             raise InterfaceError(f"unable to retrieve engine endpoint: {e}")
 
 

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -5,7 +5,7 @@ from json import JSONDecodeError
 from types import TracebackType
 from typing import Callable, List, Optional, Type
 
-from httpx import HTTPStatusError, RequestError, Timeout
+from httpx import HTTPStatusError, RequestError, Timeout, URL
 
 from firebolt.async_db.cursor import BaseCursor, Cursor
 from firebolt.client import DEFAULT_API_URL, AsyncClient
@@ -164,7 +164,7 @@ class BaseConnection:
 
     @cached_property
     def engine_name(self) -> str:
-        return self.engine_url.split('.')[0]
+        return URL(self.engine_url).host.split('.')[0]
 
     @property
     def closed(self) -> bool:

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -43,7 +43,7 @@ async def _resolve_engine_url(
             )
             response.raise_for_status()
             return response.json()["engine"]["endpoint"]
-        except HTTPStatusError as e:
+        except HTTPStatusError:
             raise FireboltEngineError(f"Firebolt engine {engine_name} does not exist")
         except (JSONDecodeError, RequestError, RuntimeError) as e:
             raise InterfaceError(f"unable to retrieve engine endpoint: {e}")

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -5,7 +5,7 @@ from json import JSONDecodeError
 from types import TracebackType
 from typing import Callable, List, Optional, Type
 
-from httpx import URL, HTTPStatusError, RequestError, Timeout
+from httpx import HTTPStatusError, RequestError, Timeout
 
 from firebolt.async_db.cursor import BaseCursor, Cursor
 from firebolt.client import DEFAULT_API_URL, AsyncClient
@@ -15,7 +15,7 @@ from firebolt.common.exception import (
     InterfaceError,
 )
 from firebolt.common.urls import ACCOUNT_ENGINE_URL, ENGINE_BY_NAME_URL
-from firebolt.common.util import cached_property, fix_url_schema
+from firebolt.common.util import fix_url_schema
 
 DEFAULT_TIMEOUT_SECONDS: int = 5
 
@@ -52,7 +52,6 @@ async def _resolve_engine_url(
             # missing engine
             raise FireboltEngineError(f"Firebolt engine {engine_name} does not exist")
         except (JSONDecodeError, RequestError, RuntimeError, HTTPStatusError) as e:
-            print("Re-raised")
             raise InterfaceError(f"unable to retrieve engine endpoint: {e}")
 
 
@@ -179,11 +178,6 @@ class BaseConnection:
             c.close()
         await self._client.aclose()
         self._is_closed = True
-
-    @cached_property
-    def _engine_name(self) -> str:
-        """Set to private since url not guaranteed to always be in this format."""
-        return URL(self.engine_url).host.split(".")[0]
 
     @property
     def closed(self) -> bool:

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -5,11 +5,15 @@ from json import JSONDecodeError
 from types import TracebackType
 from typing import Callable, List, Optional, Type
 
-from httpx import HTTPStatusError, RequestError, Timeout, URL
+from httpx import URL, HTTPStatusError, RequestError, Timeout
 
 from firebolt.async_db.cursor import BaseCursor, Cursor
 from firebolt.client import DEFAULT_API_URL, AsyncClient
-from firebolt.common.exception import ConnectionClosedError, InterfaceError, FireboltEngineError
+from firebolt.common.exception import (
+    ConnectionClosedError,
+    FireboltEngineError,
+    InterfaceError,
+)
 from firebolt.common.urls import ACCOUNT_ENGINE_URL, ENGINE_BY_NAME_URL
 from firebolt.common.util import cached_property, fix_url_schema
 
@@ -115,7 +119,14 @@ def async_connect_factory(connection_class: Type) -> Callable:
 class BaseConnection:
     client_class: type
     cursor_class: type
-    __slots__ = ("_client", "_cursors", "database", "engine_url", "api_endpoint", "_is_closed")
+    __slots__ = (
+        "_client",
+        "_cursors",
+        "database",
+        "engine_url",
+        "api_endpoint",
+        "_is_closed",
+    )
 
     def __init__(
         self,
@@ -164,7 +175,7 @@ class BaseConnection:
 
     @cached_property
     def engine_name(self) -> str:
-        return URL(self.engine_url).host.split('.')[0]
+        return URL(self.engine_url).host.split(".")[0]
 
     @property
     def closed(self) -> bool:

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -191,7 +191,8 @@ class BaseCursor:
                 )
             if not await self.is_engine_running():
                 raise EngineNotRunningError(
-                    f"Engine {self.connection.engine_name} needs to be running to run queries against it"
+                    f"Firebolt engine {self.connection.engine_name} "
+                    "needs to be running to run queries against it"
                 )
         resp.raise_for_status()
 

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -189,11 +189,9 @@ class BaseCursor:
                 raise FireboltDatabaseError(
                     f"Database {self.connection.database} does not exist"
                 )
-            if not await is_engine_running(
-                self.connection, self.connection._engine_name
-            ):
+            if not await is_engine_running(self.connection, self.connection.engine_url):
                 raise EngineNotRunningError(
-                    f"Firebolt engine {self.connection._engine_name} "
+                    f"Firebolt engine {self.connection.engine_url} "
                     "needs to be running to run queries against it"
                 )
         resp.raise_for_status()

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -38,6 +38,7 @@ from firebolt.common.exception import (
     EngineNotRunningError,
     FireboltDatabaseError,
 )
+from firebolt.common.urls import DATABASES_URL, ENGINES_URL
 
 if TYPE_CHECKING:
     from firebolt.async_db.connection import Connection
@@ -184,38 +185,37 @@ class BaseCursor:
         if resp.status_code == codes.FORBIDDEN:
             raise ProgrammingError(resp.read().decode("utf-8"))
         if resp.status_code == codes.SERVICE_UNAVAILABLE:
-            if not await self._is_db_available():
+            if not await self.is_db_available():
                 raise FireboltDatabaseError(f"Database {self.connection.database} does not exist")
-            if not await self._is_engine_running():
+            if not await self.is_engine_running():
                 raise EngineNotRunningError(f"Engine {self.connection.engine_name} needs to be running to run queries against it")
         resp.raise_for_status()
 
-    async def _is_db_available(self) -> bool:
-        """Verify if the engine is running"""
-        resp = await self._client.request(
-            # Full URL overrides the client url, which contains engine as a prefix
-            url=self.connection.api_endpoint + "/core/v1/account/databases",
-            method="GET",
-            params={
-                "filter.name_contains": self.connection.database,
-            }
-        )
+    async def is_db_available(self) -> bool:
+        """Verify if the database exists"""
+        resp = await self._filter_request(DATABASES_URL, {
+                "filter.name_contains": self.connection.database
+            })
         resp.raise_for_status()
         return len(resp.json()["edges"]) > 0
 
-    async def _is_engine_running(self) -> bool:
+    async def is_engine_running(self) -> bool:
         """Verify if the engine is running"""
-        resp = await self._client.request(
-            # Full URL overrides the client url, which contains engine as a prefix
-            url=self.connection.api_endpoint + "/core/v1/account/engines",
-            method="GET",
-            params={
+        resp = await self._filter_request(ENGINES_URL, {
                 "filter.name_contains": self.connection.engine_name,
                 "filter.current_status_eq": "ENGINE_STATUS_RUNNING",
-            }
-        )
+            })
         resp.raise_for_status()
         return len(resp.json()["edges"]) > 0
+
+    async def _filter_request(self, endpoint: str, filters: dict) -> Response:
+        resp = await self._client.request(
+                    # Full URL overrides the client url, which contains engine as a prefix
+                    url=self.connection.api_endpoint + endpoint,
+                    method="GET",
+                    params=filters
+                )
+        return resp
 
     def _reset(self) -> None:
         """Clear all data stored from previous query."""

--- a/src/firebolt/async_db/util.py
+++ b/src/firebolt/async_db/util.py
@@ -1,0 +1,36 @@
+from httpx import Response
+
+from firebolt.common.urls import DATABASES_URL, ENGINES_URL
+
+
+async def is_db_available(connection, database) -> bool:
+    """Verify if the database exists"""
+    resp = await _filter_request(
+        connection, DATABASES_URL, {"filter.name_contains": database}
+    )
+    resp.raise_for_status()
+    return len(resp.json()["edges"]) > 0
+
+
+async def is_engine_running(connection, engine) -> bool:
+    """Verify if the engine is running"""
+    resp = await _filter_request(
+        connection,
+        ENGINES_URL,
+        {
+            "filter.name_contains": engine,
+            "filter.current_status_eq": "ENGINE_STATUS_RUNNING",
+        },
+    )
+    resp.raise_for_status()
+    return len(resp.json()["edges"]) > 0
+
+
+async def _filter_request(connection, endpoint: str, filters: dict) -> Response:
+    resp = await connection._client.request(
+        # Full URL overrides the client url, which contains engine as a prefix
+        url=connection.api_endpoint + endpoint,
+        method="GET",
+        params=filters,
+    )
+    return resp

--- a/src/firebolt/async_db/util.py
+++ b/src/firebolt/async_db/util.py
@@ -1,36 +1,47 @@
-from httpx import Response
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from httpx import URL, Response
 
 from firebolt.common.urls import DATABASES_URL, ENGINES_URL
 
+if TYPE_CHECKING:
+    from firebolt.async_db.connection import Connection
 
-async def is_db_available(connection, database) -> bool:
+
+async def is_db_available(connection: Connection, database_name: str) -> bool:
     """Verify if the database exists"""
     resp = await _filter_request(
-        connection, DATABASES_URL, {"filter.name_contains": database}
+        connection, DATABASES_URL, {"filter.name_contains": database_name}
     )
-    resp.raise_for_status()
     return len(resp.json()["edges"]) > 0
 
 
-async def is_engine_running(connection, engine) -> bool:
+async def is_engine_running(connection: Connection, engine_url: str) -> bool:
     """Verify if the engine is running"""
+    # Url is not always guaranteed to be of this structure
+    # but for the sake of error check this is sufficient
+    engine_name = URL(engine_url).host.split(".")[0]
     resp = await _filter_request(
         connection,
         ENGINES_URL,
         {
-            "filter.name_contains": engine,
+            "filter.name_contains": engine_name,
             "filter.current_status_eq": "ENGINE_STATUS_RUNNING",
         },
     )
-    resp.raise_for_status()
     return len(resp.json()["edges"]) > 0
 
 
-async def _filter_request(connection, endpoint: str, filters: dict) -> Response:
+async def _filter_request(
+    connection: Connection, endpoint: str, filters: dict
+) -> Response:
     resp = await connection._client.request(
         # Full URL overrides the client url, which contains engine as a prefix
         url=connection.api_endpoint + endpoint,
         method="GET",
         params=filters,
     )
+    resp.raise_for_status()
     return resp

--- a/src/firebolt/common/exception.py
+++ b/src/firebolt/common/exception.py
@@ -9,6 +9,10 @@ class FireboltEngineError(FireboltError):
     """Base error for engine errors."""
 
 
+class EngineNotRunningError(FireboltEngineError):
+    pass
+
+
 class NoAttachedDatabaseError(FireboltEngineError):
     def __init__(self, method_name: str):
         self.method_name = method_name

--- a/src/firebolt/common/urls.py
+++ b/src/firebolt/common/urls.py
@@ -1,6 +1,9 @@
 AUTH_URL = "{api_endpoint}/auth/v1/login"
 
+DATABASES_URL = "/core/v1/account/databases"
+
 ENGINE_BY_NAME_URL = "/core/v1/account/engines:getIdByName"
+ENGINES_URL = "/core/v1/account/engines"
 ENGINES_BY_IDS_URL = "/core/v1/engines:getByIds"
 
 ACCOUNT_URL = "/iam/v2/account"

--- a/src/firebolt/service/engine.py
+++ b/src/firebolt/service/engine.py
@@ -1,5 +1,6 @@
 from logging import getLogger
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Callable, Any
+from functools import wraps
 
 from firebolt.common.urls import (
     ACCOUNT_ENGINE_BY_NAME_URL,
@@ -19,6 +20,7 @@ from firebolt.service.base import BaseService
 from firebolt.service.types import EngineOrder, EngineType, WarmupMethod
 
 logger = getLogger(__name__)
+
 
 
 class EngineService(BaseService):

--- a/src/firebolt/service/engine.py
+++ b/src/firebolt/service/engine.py
@@ -1,6 +1,5 @@
 from logging import getLogger
 from typing import List, Optional, Union
-from functools import wraps
 
 from firebolt.common.urls import (
     ACCOUNT_ENGINE_BY_NAME_URL,

--- a/src/firebolt/service/engine.py
+++ b/src/firebolt/service/engine.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import List, Optional, Union, Callable, Any
+from typing import List, Optional, Union
 from functools import wraps
 
 from firebolt.common.urls import (
@@ -20,7 +20,6 @@ from firebolt.service.base import BaseService
 from firebolt.service.types import EngineOrder, EngineType, WarmupMethod
 
 logger = getLogger(__name__)
-
 
 
 class EngineService(BaseService):

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -160,7 +160,7 @@ async def test_connect_engine_name(
         url=f"https://{settings.server}"
         + ENGINE_BY_NAME_URL
         + f"?engine_name={engine_name}",
-        status_code=codes.INTERNAL_SERVER_ERROR,
+        status_code=codes.NOT_FOUND,
     )
 
     with raises(FireboltEngineError) as exc_info:

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -6,7 +6,7 @@ from pytest_httpx import HTTPXMock
 
 from firebolt.async_db import Connection, connect
 from firebolt.async_db._types import ColType
-from firebolt.common.exception import ConnectionClosedError, InterfaceError
+from firebolt.common.exception import ConnectionClosedError, InterfaceError, FireboltEngineError
 from firebolt.common.settings import Settings
 from firebolt.common.urls import ENGINE_BY_NAME_URL
 
@@ -150,6 +150,24 @@ async def test_connect_engine_name(
     httpx_mock.add_callback(get_engine_callback, url=get_engine_url)
 
     engine_name = settings.server.split(".")[0]
+
+    # Mock engine id lookup error
+    httpx_mock.add_response(
+        url=f"https://{settings.server}"
+        + ENGINE_BY_NAME_URL
+        + f"?engine_name={engine_name}",
+        status_code=codes.INTERNAL_SERVER_ERROR,
+    )
+
+    with raises(FireboltEngineError) as exc_info:
+        async with await connect(
+            database="db",
+            username="username",
+            password="password",
+            engine_name=engine_name,
+            api_endpoint=settings.server,
+        ):
+            pass
 
     # Mock engine id lookup by name
     httpx_mock.add_response(

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -6,7 +6,11 @@ from pytest_httpx import HTTPXMock
 
 from firebolt.async_db import Connection, connect
 from firebolt.async_db._types import ColType
-from firebolt.common.exception import ConnectionClosedError, InterfaceError, FireboltEngineError
+from firebolt.common.exception import (
+    ConnectionClosedError,
+    FireboltEngineError,
+    InterfaceError,
+)
 from firebolt.common.settings import Settings
 from firebolt.common.urls import ENGINE_BY_NAME_URL
 

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -10,10 +10,10 @@ from firebolt.async_db._types import Column
 from firebolt.async_db.cursor import ColType, CursorState
 from firebolt.common.exception import (
     CursorClosedError,
+    EngineNotRunningError,
+    FireboltDatabaseError,
     OperationalError,
     QueryNotRunError,
-    FireboltDatabaseError,
-    EngineNotRunningError,
 )
 
 
@@ -233,8 +233,8 @@ async def test_cursor_execute_error(
             url=query_url,
         )
         httpx_mock.add_response(
-            json={"edges":[]},
-            url=get_databases_url+"?filter.name_contains=database",
+            json={"edges": []},
+            url=get_databases_url + "?filter.name_contains=database",
         )
         with raises(FireboltDatabaseError) as excinfo:
             await query()
@@ -246,14 +246,15 @@ async def test_cursor_execute_error(
             url=query_url,
         )
         httpx_mock.add_response(
-            json={"edges":["dummy"]}, # indicate db exists
-            url=get_databases_url+"?filter.name_contains=database",
+            json={"edges": ["dummy"]},  # indicate db exists
+            url=get_databases_url + "?filter.name_contains=database",
         )
         httpx_mock.add_response(
-            json={"edges":[]},
-            url= (get_engines_url +
-                  "?filter.name_contains=api"
-                  "&filter.current_status_eq=ENGINE_STATUS_RUNNING"),
+            json={"edges": []},
+            url=(
+                get_engines_url + "?filter.name_contains=api"
+                "&filter.current_status_eq=ENGINE_STATUS_RUNNING"
+            ),
         )
         with raises(EngineNotRunningError) as excinfo:
             await query()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,9 +11,9 @@ from firebolt.common.urls import (
     ACCOUNT_ENGINE_URL,
     ACCOUNT_URL,
     AUTH_URL,
-    PROVIDERS_URL,
-    ENGINES_URL,
     DATABASES_URL,
+    ENGINES_URL,
+    PROVIDERS_URL,
 )
 from firebolt.model.provider import Provider
 from firebolt.model.region import Region, RegionKey
@@ -193,9 +193,11 @@ def get_providers_callback(get_providers_url: str, provider: Provider) -> Callab
 
     return do_mock
 
+
 @pytest.fixture
 def get_engines_url(settings: Settings) -> str:
     return f"https://{settings.server}{ENGINES_URL}"
+
 
 @pytest.fixture
 def get_databases_url(settings: Settings) -> str:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,8 @@ from firebolt.common.urls import (
     ACCOUNT_URL,
     AUTH_URL,
     PROVIDERS_URL,
+    ENGINES_URL,
+    DATABASES_URL,
 )
 from firebolt.model.provider import Provider
 from firebolt.model.region import Region, RegionKey
@@ -190,3 +192,11 @@ def get_providers_callback(get_providers_url: str, provider: Provider) -> Callab
         )
 
     return do_mock
+
+@pytest.fixture
+def get_engines_url(settings: Settings) -> str:
+    return f"https://{settings.server}{ENGINES_URL}"
+
+@pytest.fixture
+def get_databases_url(settings: Settings) -> str:
+    return f"https://{settings.server}{DATABASES_URL}"


### PR DESCRIPTION
In order to ease new client sdk integration I'm improving the error messages the users are likely to get on failed connection.
This reduces the need to reach out to us when something fails and allows for faster user feedback if something that's controlled by them is incorrect (e.g. database name is mistyped or engine is not running).