### PR TITLE
Fir-9475: Allow getting cheapest instance from RM

### DIFF
--- a/src/firebolt/service/instance_type.py
+++ b/src/firebolt/service/instance_type.py
@@ -24,7 +24,11 @@ class BaseFilter(ABC):
 class HasStorage(BaseFilter):
     @staticmethod
     def filter(instances: Dict[Any, InstanceType]) -> Dict[Any, InstanceType]:
-        return {k: v for k, v in instances.items() if v.storage_size_bytes != "0"}
+        return {
+            k: v
+            for k, v in instances.items()
+            if v.storage_size_bytes and v.storage_size_bytes != "0"
+        }
 
 
 class InstanceTypeService(BaseService):
@@ -55,8 +59,9 @@ class InstanceTypeService(BaseService):
     @cached_property
     def instance_types_by_cost(self) -> Dict[float, InstanceType]:
         return {
-            i.price_per_hour_cents if i.price_per_hour_cents else 0.0: i
+            i.price_per_hour_cents: i
             for i in self.instance_types
+            if i.price_per_hour_cents
         }
 
     @staticmethod

--- a/src/firebolt/service/instance_type.py
+++ b/src/firebolt/service/instance_type.py
@@ -38,6 +38,22 @@ class InstanceTypeService(BaseService):
             for i in self.instance_types
         }
 
+    @cached_property
+    def instance_types_by_cost(self) -> Dict[float, InstanceType]:
+        return {i.price_per_hour_cents: i for i in self.instance_types}
+
+    def get_cheapest(self, with_storage=False):
+        instances = (
+            {
+                k: v
+                for k, v in self.instance_types_by_cost.items()
+                if v.storage_size_bytes != "0"
+            }
+            if with_storage
+            else self.instance_types_by_cost
+        )
+        return instances[min(instances)]
+
     def get_by_key(self, instance_type_key: InstanceTypeKey) -> InstanceType:
         """Get an instance type by key."""
         return self.instance_types_by_key[instance_type_key]

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -55,6 +55,7 @@ def instance_type_1(provider, region_1) -> InstanceType:
             instance_type_id="instance_type_id_1",
         ),
         name="i3.4xlarge",
+        price_per_hour_cents=0.02,
     )
 
 
@@ -67,12 +68,28 @@ def instance_type_2(provider, region_2) -> InstanceType:
             instance_type_id="instance_type_id_2",
         ),
         name="i3.8xlarge",
+        price_per_hour_cents=1.12,
+        storage_size_bytes="1024",
     )
 
 
 @pytest.fixture
-def mock_instance_types(instance_type_1, instance_type_2) -> List[InstanceType]:
-    return [instance_type_1, instance_type_2]
+def instance_type_3(provider, region_2) -> InstanceType:
+    return InstanceType(
+        key=InstanceTypeKey(
+            provider_id=provider.provider_id,
+            region_id=region_2.key.region_id,
+            instance_type_id="instance_type_id_2",
+        ),
+        name="i3.8xlarge",
+    )
+
+
+@pytest.fixture
+def mock_instance_types(
+    instance_type_1, instance_type_2, instance_type_3
+) -> List[InstanceType]:
+    return [instance_type_1, instance_type_2, instance_type_3]
 
 
 @pytest.fixture

--- a/tests/unit/service/test_instance_type.py
+++ b/tests/unit/service/test_instance_type.py
@@ -30,8 +30,22 @@ def test_instance_type(
     manager = ResourceManager(settings=settings)
     assert manager.instance_types.instance_types == mock_instance_types
 
+    # Make sure test conditions are met
+    assert (
+        mock_instance_types[0].price_per_hour_cents
+        < mock_instance_types[1].price_per_hour_cents
+    )
+    assert not mock_instance_types[2].price_per_hour_cents
+
+    # Get cheapest instance
     assert manager.instance_types.get_cheapest() == mock_instance_types[0]
 
+    # Make sure test conditions are met
+    assert (
+        not mock_instance_types[0].storage_size_bytes
+        or mock_instance_types[0].storage_size_bytes == "0"
+    )
+    # Get cheapest instance that also has storage
     assert (
         manager.instance_types.get_cheapest(filters=[HasStorage])
         == mock_instance_types[1]

--- a/tests/unit/service/test_instance_type.py
+++ b/tests/unit/service/test_instance_type.py
@@ -4,6 +4,7 @@ from pytest_httpx import HTTPXMock
 
 from firebolt.common import Settings
 from firebolt.model.instance_type import InstanceType
+from firebolt.service.instance_type import HasStorage
 from firebolt.service.manager import ResourceManager
 
 
@@ -28,3 +29,10 @@ def test_instance_type(
 
     manager = ResourceManager(settings=settings)
     assert manager.instance_types.instance_types == mock_instance_types
+
+    assert manager.instance_types.get_cheapest() == mock_instance_types[0]
+
+    assert (
+        manager.instance_types.get_cheapest(filters=[HasStorage])
+        == mock_instance_types[1]
+    )


### PR DESCRIPTION
In order to be instance-name independent we want to pick the cheapest instance from the available list for our integration tests.

Limitation: There's no way to limit or filter by the type of instances (e.g. Balanced or Compute) so the cheapest instance turns out to be a compute-optimised one.