### PR TITLE
ci: FIR9441 Adding PR title validation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,3 +40,9 @@ jobs:
     - name: Test with pytest
       run: |
         pytest tests/unit
+        
+    - name: Convetional Commits Pull Request Title
+      uses: jef/conventional-commits-pr-action@v1.0.0
+      if: github.event_name == 'pull_request'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ref: https://github.com/marketplace/actions/convetional-commits-pull-request
This action will validate PR title and post a comment if it does not pass the tests. If title is modified it reruns to validate and if everything's ok the comment will be removed. 

Example of alternatives considered:
https://github.com/ptiurin/integration-testing-setup/pull/2
However, I believe the current one looks and explains what's breaking better.