### PR TITLE
fix: increase timeout for resource manager operations

### DIFF
--- a/src/firebolt/client/constants.py
+++ b/src/firebolt/client/constants.py
@@ -1,10 +1,9 @@
 from json import JSONDecodeError
-from typing import Optional, Tuple, Type
+from typing import Tuple, Type
 
 from httpx import CookieConflict, HTTPError, InvalidURL, StreamError
 
 DEFAULT_API_URL: str = "api.app.firebolt.io"
-API_REQUEST_TIMEOUT_SECONDS: Optional[int] = 60
 _REQUEST_ERRORS: Tuple[Type, ...] = (
     HTTPError,
     InvalidURL,

--- a/src/firebolt/service/manager.py
+++ b/src/firebolt/service/manager.py
@@ -1,9 +1,13 @@
 from typing import Optional
 
+from httpx import Timeout
+
 from firebolt.client import Client, log_request, log_response, raise_on_4xx_5xx
 from firebolt.common import Settings
 from firebolt.common.urls import ACCOUNT_BY_NAME_URL
 from firebolt.service.provider import get_provider_id
+
+DEFAULT_TIMEOUT_SECONDS: int = 60 * 2
 
 
 class ResourceManager:
@@ -29,6 +33,7 @@ class ResourceManager:
             auth=(self.settings.user, self.settings.password.get_secret_value()),
             base_url=f"https://{ self.settings.server}",
             api_endpoint=self.settings.server,
+            timeout=Timeout(DEFAULT_TIMEOUT_SECONDS),
         )
         self.client.event_hooks = {
             "request": [log_request],


### PR DESCRIPTION
Increased ResourceManager operations timeout from 5 seconds to 2 minutes.
This is required for integration tests since they fail with ReadTimeout error from time to time