### PR TITLE
build: typed option in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     readerwriterlock==1.0.9
     syncer==1.3.0
 python_requires = >=3.7
+include_package_data = True
 package_dir =
     = src
 
@@ -48,6 +49,9 @@ dev =
     pytest-cov==3.0.0
     pytest-httpx==0.13.0
     pytest-mock==3.6.1
+
+[options.package_data]
+firebolt = py.typed
 
 [mypy]
 plugins = pydantic.mypy


### PR DESCRIPTION
This setting allows mypy checks in packages that use firebolt-sdk.