### PR TITLE
fix: add custom loop for connection __del__

### DIFF
--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -59,8 +59,9 @@ class Connection(AsyncBaseConnection):
     @wraps(AsyncBaseConnection._aclose)
     def close(self) -> None:
         with self._closing_lock.gen_wlock():
-            self._loop.run_until_complete(self._aclose())
-            self._loop.close()
+            if not self.closed:
+                self._loop.run_until_complete(self._aclose())
+                self._loop.close()
 
     # Context manager support
     def __enter__(self) -> Connection:

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from asyncio import new_event_loop
 from functools import wraps
 from inspect import cleandoc
 from types import TracebackType
@@ -37,7 +38,7 @@ class Connection(AsyncBaseConnection):
         """
     )
 
-    __slots__ = AsyncBaseConnection.__slots__ + ("_closing_lock",)
+    __slots__ = AsyncBaseConnection.__slots__ + ("_closing_lock", "_loop")
 
     cursor_class = Cursor
 
@@ -46,6 +47,7 @@ class Connection(AsyncBaseConnection):
         # Holding this lock for write means that connection is closing itself.
         # cursor() should hold this lock for read to read/write state
         self._closing_lock = RWLockWrite()
+        self._loop = new_event_loop()
 
     @wraps(AsyncBaseConnection.cursor)
     def cursor(self) -> Cursor:
@@ -57,7 +59,7 @@ class Connection(AsyncBaseConnection):
     @wraps(AsyncBaseConnection._aclose)
     def close(self) -> None:
         with self._closing_lock.gen_wlock():
-            return async_to_sync(super()._aclose)()
+            return self._loop.run_until_complete(self._aclose())
 
     # Context manager support
     def __enter__(self) -> Connection:

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -59,7 +59,8 @@ class Connection(AsyncBaseConnection):
     @wraps(AsyncBaseConnection._aclose)
     def close(self) -> None:
         with self._closing_lock.gen_wlock():
-            return self._loop.run_until_complete(self._aclose())
+            self._loop.run_until_complete(self._aclose())
+            self._loop.close()
 
     # Context manager support
     def __enter__(self) -> Connection:


### PR DESCRIPTION
Apparently, I've finally managed to investigate the issue with `RuntimeWarning: coroutine 'BaseConnection._aclose' was never awaited` in tests.
It seems like `connection.__del__` function (which inside calls asynchronous `_aclose` in global event loop) sometimes gets called after the event loop is closed (because it's called by the garbage collector in background). To fix this, added a custom loop for connection to use it for closing. I assume this issue could happen in real environments too.