### PR TITLE
fix: async_to_sync tests

### DIFF
--- a/tests/unit/common/test_util.py
+++ b/tests/unit/common/test_util.py
@@ -1,11 +1,42 @@
 from asyncio import run
+from threading import Thread
 
 from pytest import raises
 
 from firebolt.common.util import async_to_sync
 
 
-def test_async_to_sync():
+def test_async_to_sync_happy_path():
+    """async_to_sync properly converts coroutine to sync function"""
+
+    class JobMarker(Exception):
+        pass
+
+    async def task():
+        raise JobMarker()
+
+    for i in range(3):
+        with raises(JobMarker):
+            async_to_sync(task)()
+
+
+def test_async_to_sync_thread():
+    """async_to_sync properly works in threads"""
+
+    marks = [False] * 3
+
+    async def task(id: int):
+        marks[id] = True
+
+    ts = [Thread(target=async_to_sync(task), args=[i]) for i in range(3)]
+    [t.start() for t in ts]
+    [t.join() for t in ts]
+    assert all(marks)
+
+
+def test_async_to_sync_after_run():
+    """async_to_sync properly runs after asyncio.run"""
+
     class JobMarker(Exception):
         pass
 

--- a/tests/unit/common/test_util.py
+++ b/tests/unit/common/test_util.py
@@ -1,0 +1,21 @@
+from asyncio import run
+
+from pytest import raises
+
+from firebolt.common.util import async_to_sync
+
+
+def test_async_to_sync():
+    class JobMarker(Exception):
+        pass
+
+    async def task():
+        raise JobMarker()
+
+    with raises(JobMarker):
+        run(task())
+
+    # Here local event loop is closed by run
+
+    with raises(JobMarker):
+        async_to_sync(task)()


### PR DESCRIPTION
Add tests for `async_to_sync` function, since it's been flaky for recently.
Also, added a real case of using `async_to_sync` with `asyncio.run`, which cased an error. Fixed the error