### PR TITLE
refactor: Exposing exceptions on module level

### DIFF
--- a/src/firebolt/async_db/__init__.py
+++ b/src/firebolt/async_db/__init__.py
@@ -15,6 +15,18 @@ from firebolt.async_db._types import (
 )
 from firebolt.async_db.connection import Connection, connect
 from firebolt.async_db.cursor import Cursor
+from firebolt.common.exception import (
+    DatabaseError,
+    DataError,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+    Warning,
+)
 
 apilevel = "2.0"
 # threads may only share the module and connections, cursors should not be shared

--- a/src/firebolt/db/__init__.py
+++ b/src/firebolt/db/__init__.py
@@ -13,6 +13,18 @@ from firebolt.async_db._types import (
     Timestamp,
     TimestampFromTicks,
 )
+from firebolt.common.exception import (
+    DatabaseError,
+    DataError,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+    Warning,
+)
 from firebolt.db.connection import Connection, connect
 from firebolt.db.cursor import Cursor
 

--- a/tests/unit/async_db/test_module.py
+++ b/tests/unit/async_db/test_module.py
@@ -1,0 +1,7 @@
+import firebolt.async_db
+
+
+def test_has_exceptions(db_api_exceptions):
+    """Verify async module has top-level dbapi exceptions exposed"""
+    for ex_name, ex_class in db_api_exceptions.items():
+        assert issubclass(getattr(firebolt.async_db, ex_name), ex_class)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,6 +6,18 @@ from pydantic import SecretStr
 from pytest_httpx import to_response
 from pytest_httpx._httpx_internals import Response
 
+from firebolt.common.exception import (
+    DatabaseError,
+    DataError,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+    Warning,
+)
 from firebolt.common.settings import Settings
 from firebolt.common.urls import (
     ACCOUNT_ENGINE_URL,
@@ -202,3 +214,20 @@ def get_engines_url(settings: Settings) -> str:
 @pytest.fixture
 def get_databases_url(settings: Settings) -> str:
     return f"https://{settings.server}{DATABASES_URL}"
+
+
+@pytest.fixture
+def db_api_exceptions():
+    exceptions = {
+        "DatabaseError": DatabaseError,
+        "DataError": DataError,
+        "Error": Error,
+        "IntegrityError": IntegrityError,
+        "InterfaceError": InterfaceError,
+        "InternalError": InternalError,
+        "NotSupportedError": NotSupportedError,
+        "OperationalError": OperationalError,
+        "ProgrammingError": ProgrammingError,
+        "Warning": Warning,
+    }
+    return exceptions

--- a/tests/unit/db/test_module.py
+++ b/tests/unit/db/test_module.py
@@ -1,0 +1,7 @@
+import firebolt.db
+
+
+def test_has_exceptions(db_api_exceptions):
+    """Verify sync module has top-level dbapi exceptions exposed"""
+    for ex_name, ex_class in db_api_exceptions.items():
+        assert issubclass(getattr(firebolt.db, ex_name), ex_class)


### PR DESCRIPTION
Exposing dbapi exceptions on firebolt.db and firebolt.async_db level. This conforms to PEP-249 and simplifies SQLAlchemy connector design.