### PR TITLE
feat: implement Connection.commit, DataError on empty data fetch

### DIFF
--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -191,7 +191,7 @@ class BaseConnection:
         except ValueError:
             pass
 
-    def commit(self):
+    def commit(self) -> None:
         """Does nothing since Firebolt doesn't have transactions"""
         if self.closed:
             raise ConnectionClosedError("Unable to commit: connection closed")

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -191,6 +191,11 @@ class BaseConnection:
         except ValueError:
             pass
 
+    def commit(self):
+        """Does nothing since Firebolt doesn't have transactions"""
+        if self.closed:
+            raise ConnectionClosedError("Unable to commit: connection closed")
+
 
 class Connection(BaseConnection):
     cleandoc(

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -290,9 +290,11 @@ class BaseCursor:
             and update _idx to point to the end of this range
             """
         )
+
         if self._rows is None:
             # No elements to take
-            return (0, 0)
+            raise DataError("no rows to fetch")
+
         left = self._idx
         right = min(self._idx + size, len(self._rows))
         self._idx = right
@@ -328,8 +330,8 @@ class BaseCursor:
     @check_query_executed
     def fetchall(self) -> List[List[ColType]]:
         """Fetch all remaining rows of a query result."""
+        left, right = self._get_next_range(self.rowcount)
         assert self._rows is not None
-        left, right = self._get_next_range(len(self._rows))
         rows = self._rows[left:right]
         return [self._parse_row(row) for row in rows]
 

--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -1,9 +1,9 @@
 from datetime import date, datetime
 from typing import Any, List
 
-from pytest import mark
+from pytest import mark, raises
 
-from firebolt.async_db import Connection, Cursor
+from firebolt.async_db import Connection, Cursor, DataError
 from firebolt.async_db._types import ColType, Column
 
 
@@ -137,7 +137,14 @@ async def test_insert(connection: Connection) -> None:
         assert await c.execute(query) == -1, "Invalid row count returned"
         assert c.rowcount == -1, "Invalid rowcount value"
         assert c.description is None, "Invalid description"
-        assert await c.fetchone() is None, "Invalid data returned"
+        with raises(DataError):
+            await c.fetchone()
+
+        with raises(DataError):
+            await c.fetchmany()
+
+        with raises(DataError):
+            await c.fetchall()
 
     with connection.cursor() as c:
         await c.execute("DROP TABLE IF EXISTS test_tb")

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -1,9 +1,11 @@
 from datetime import date, datetime
 from typing import Any, List
 
+from pytest import raises
+
 from firebolt.async_db._types import ColType
 from firebolt.async_db.cursor import Column
-from firebolt.db import Connection, Cursor
+from firebolt.db import Connection, Cursor, DataError
 
 
 def assert_deep_eq(got: Any, expected: Any, msg: str) -> bool:
@@ -128,7 +130,14 @@ def test_insert(connection: Connection) -> None:
         assert c.execute(query) == -1, "Invalid row count returned"
         assert c.rowcount == -1, "Invalid rowcount value"
         assert c.description is None, "Invalid description"
-        assert c.fetchone() is None, "Invalid data returned"
+        with raises(DataError):
+            c.fetchone()
+
+        with raises(DataError):
+            c.fetchmany()
+
+        with raises(DataError):
+            c.fetchall()
 
     with connection.cursor() as c:
         c.execute("DROP TABLE IF EXISTS test_tb")

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -190,3 +190,13 @@ async def test_connect_engine_name(
         api_endpoint=settings.server,
     ) as connection:
         assert await connection.cursor().execute("select*") == len(python_query_data)
+
+
+@mark.asyncio
+async def test_connection_commit(connection: Connection):
+    # nothing happens
+    connection.commit()
+
+    await connection.aclose()
+    with raises(ConnectionClosedError):
+        connection.commit()

--- a/tests/unit/db/test_connection.py
+++ b/tests/unit/db/test_connection.py
@@ -168,3 +168,12 @@ def test_connection_unclosed_warnings():
     assert "Unclosed" in str(
         winfo.list[0].message
     ), "Invalid unclosed connection warning"
+
+
+def test_connection_commit(connection: Connection):
+    # nothing happens
+    connection.commit()
+
+    connection.close()
+    with raises(ConnectionClosedError):
+        connection.commit()


### PR DESCRIPTION
Improvements for PEP-249 conformance
- Added `connection.commit` method with void functionality
- Raise `DataError` when no data was returned from query

closes #74  