### PR TITLE
ci: Passing secrets on release action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,11 @@ name: Run integration tests
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      FIREBOLT_USERNAME:
+        required: true
+      FIREBOLT_PASSWORD:
+        required: true
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: firebolt-db/firebolt-python-sdk/.github/workflows/integration-tests.yml@main
+    uses: firebolt-db/firebolt-python-sdk/.github/workflows/integration-tests.yml@ci_add_secrets
     secrets:
       FIREBOLT_USERNAME: ${{ secrets.FIREBOLT_USERNAME }}
       FIREBOLT_PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: firebolt-db/firebolt-python-sdk/.github/workflows/integration-tests.yml@ci_add_secrets
+    uses: firebolt-db/firebolt-python-sdk/.github/workflows/integration-tests.yml@main
     secrets:
       FIREBOLT_USERNAME: ${{ secrets.FIREBOLT_USERNAME }}
       FIREBOLT_PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   integration-tests:
     uses: firebolt-db/firebolt-python-sdk/.github/workflows/integration-tests.yml@main
+    secrets:
+      FIREBOLT_USERNAME: ${{ secrets.FIREBOLT_USERNAME }}
+      FIREBOLT_PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Secrets have to be explicitly passed down to the integration test workflow on call.