### PR TITLE
fix: raise NotSupportedError for parametierized queries

### DIFF
--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -38,6 +38,7 @@ from firebolt.common.exception import (
     DataError,
     EngineNotRunningError,
     FireboltDatabaseError,
+    NotSupportedError,
     OperationalError,
     ProgrammingError,
     QueryNotRunError,
@@ -218,6 +219,9 @@ class BaseCursor:
         parameters: Optional[Sequence[ParameterType]] = None,
         set_parameters: Optional[Dict] = None,
     ) -> Response:
+        if parameters:
+            raise NotSupportedError("parametrized queries are not supported")
+
         resp = await self._client.request(
             url="/",
             method="POST",

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -13,6 +13,7 @@ from firebolt.common.exception import (
     DataError,
     EngineNotRunningError,
     FireboltDatabaseError,
+    NotSupportedError,
     OperationalError,
     QueryNotRunError,
 )
@@ -406,3 +407,13 @@ async def test_set_parameters(
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(query_with_params_callback, url=query_with_params_url)
     await cursor.execute("select 1", set_parameters=set_params)
+
+
+@mark.asyncio
+async def test_cursor_execute_parameters(cursor: Cursor):
+    """execute and executemany with parameters are not supported"""
+    with raises(NotSupportedError):
+        await cursor.execute("select ?", (1,))
+
+    with raises(NotSupportedError):
+        await cursor.executemany("select ?", [(1,), (2,)])

--- a/tests/unit/db/test_cursor.py
+++ b/tests/unit/db/test_cursor.py
@@ -9,6 +9,7 @@ from firebolt.async_db.cursor import ColType, Column, CursorState
 from firebolt.common.exception import (
     CursorClosedError,
     DataError,
+    NotSupportedError,
     OperationalError,
     QueryNotRunError,
 )
@@ -354,3 +355,12 @@ def test_set_parameters(
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(query_with_params_callback, url=query_with_params_url)
     cursor.execute("select 1", set_parameters=set_params)
+
+
+def test_cursor_execute_parameters(cursor: Cursor):
+    """execute and executemany with parameters are not supported"""
+    with raises(NotSupportedError):
+        cursor.execute("select ?", (1,))
+
+    with raises(NotSupportedError):
+        cursor.executemany("select ?", [(1,), (2,)])


### PR DESCRIPTION
Since we currently don't support parameterized sql queries, raise an error if one is being executed