### PR TITLE
feat: migrate from asyncio to trio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,11 +24,10 @@ project_urls =
 packages = find:
 install_requires =
     aiorwlock==1.1.0
-    async-property==0.2.1
     httpx[http2]==0.19.0
     pydantic[dotenv]==1.8.2
     readerwriterlock==1.0.9
-    syncer==1.3.0
+    trio==0.19.0
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ dev =
     pytest-cov==3.0.0
     pytest-httpx==0.13.0
     pytest-mock==3.6.1
+    trio-typing==0.7.0
 release =
     argparse
     build

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -34,7 +34,7 @@ async def _resolve_engine_url(
             )
             response.raise_for_status()
             engine_id = response.json()["engine_id"]["engine_id"]
-            account_id = await client.account_id
+            account_id = await client.account_id()
             response = await client.get(
                 url=ACCOUNT_ENGINE_URL.format(
                     account_id=account_id, engine_id=engine_id

--- a/src/firebolt/client/client.py
+++ b/src/firebolt/client/client.py
@@ -1,6 +1,5 @@
 from typing import Any, Optional
 
-from async_property import async_cached_property  # type: ignore
 from httpx import AsyncClient as HttpxAsyncClient
 from httpx import Client as HttpxClient
 from httpx import _types
@@ -70,6 +69,5 @@ class AsyncClient(FireboltClientMixin, HttpxAsyncClient):
     + (HttpxAsyncClient.__doc__ or "")
     """
 
-    @async_cached_property
     async def account_id(self) -> str:
         return (await self.get(url=ACCOUNT_URL)).json()["account"]["id"]

--- a/src/firebolt/common/util.py
+++ b/src/firebolt/common/util.py
@@ -1,6 +1,7 @@
-from asyncio import get_event_loop, new_event_loop
-from functools import lru_cache, wraps
+from functools import lru_cache, partial, wraps
 from typing import TYPE_CHECKING, Any, Callable, Type, TypeVar
+
+from trio import run as sync_run
 
 T = TypeVar("T")
 
@@ -40,15 +41,6 @@ def fix_url_schema(url: str) -> str:
 def async_to_sync(f: Callable) -> Callable:
     @wraps(f)
     def sync(*args: Any, **kwargs: Any) -> Any:
-        close = False
-        try:
-            loop = get_event_loop()
-        except RuntimeError:
-            loop = new_event_loop()
-            close = True
-        res = loop.run_until_complete(f(*args, **kwargs))
-        if close:
-            loop.close()
-        return res
+        return sync_run(partial(f, *args, **kwargs))
 
     return sync

--- a/tests/unit/client/test_client_async.py
+++ b/tests/unit/client/test_client_async.py
@@ -112,4 +112,4 @@ async def test_client_account_id(
         base_url=fix_url_schema(settings.server),
         api_endpoint=settings.server,
     ) as c:
-        assert await c.account_id == account_id, "Invalid account id returned"
+        assert await c.account_id() == account_id, "Invalid account id returned"

--- a/tests/unit/common/test_util.py
+++ b/tests/unit/common/test_util.py
@@ -1,7 +1,7 @@
-from asyncio import run
 from threading import Thread
 
 from pytest import raises
+from trio import run
 
 from firebolt.common.util import async_to_sync
 
@@ -44,7 +44,7 @@ def test_async_to_sync_after_run():
         raise JobMarker()
 
     with raises(JobMarker):
-        run(task())
+        run(task)
 
     # Here local event loop is closed by run
 


### PR DESCRIPTION
We need to migrate from using asyncio as async backend to trio.
It seems like asyncio has a bug, which causes tcp transport to raise "Event loop closed" error on close in some cases.
Trio, on the other hand, seems not to have this issue