### PR TITLE
fix: Asyncio set global loop

### DIFF
--- a/src/firebolt/common/util.py
+++ b/src/firebolt/common/util.py
@@ -1,4 +1,4 @@
-from asyncio import get_event_loop, new_event_loop
+from asyncio import get_event_loop, new_event_loop, set_event_loop
 from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any, Callable, Type, TypeVar
 
@@ -40,15 +40,12 @@ def fix_url_schema(url: str) -> str:
 def async_to_sync(f: Callable) -> Callable:
     @wraps(f)
     def sync(*args: Any, **kwargs: Any) -> Any:
-        close = False
         try:
             loop = get_event_loop()
         except RuntimeError:
             loop = new_event_loop()
-            close = True
+            set_event_loop(loop)
         res = loop.run_until_complete(f(*args, **kwargs))
-        if close:
-            loop.close()
         return res
 
     return sync


### PR DESCRIPTION
Set global loop to new if it's empty instead of opening and closing a new one each time