### PR TITLE
feat: Fir 8425 implement multi statement funct

### DIFF
--- a/src/firebolt/async_db/_types.py
+++ b/src/firebolt/async_db/_types.py
@@ -265,7 +265,7 @@ def format_sql(query: str, parameters: Sequence[ParameterType]) -> str:
 
 
 def split_format_sql(
-    query: str, parameters: Sequence(Sequence[ParameterType])
+    query: str, parameters: Sequence[Sequence[ParameterType]]
 ) -> List[str]:
     statements = parse_sql(query)
     if not statements:

--- a/src/firebolt/async_db/_types.py
+++ b/src/firebolt/async_db/_types.py
@@ -245,7 +245,8 @@ def format_statement(statement: Statement, parameters: Sequence[ParameterType]) 
             return Token(TokenType.Text, formatted)
         if isinstance(token, TokenList):
             # Process all children tokens
-            token.tokens = [process_token(t) for t in token.tokens]
+
+            return TokenList([process_token(t) for t in token.tokens])
         return token
 
     formatted_sql = str(process_token(statement)).rstrip(";")
@@ -263,7 +264,9 @@ def format_sql(query: str, parameters: Sequence[ParameterType]) -> str:
     return format_statement(parse_sql(query)[0], parameters)
 
 
-def split_format_sql(query: str, parameters: Sequence[ParameterType]) -> List[str]:
+def split_format_sql(
+    query: str, parameters: Sequence(Sequence[ParameterType])
+) -> List[str]:
     statements = parse_sql(query)
     if not statements:
         return [query]
@@ -273,5 +276,5 @@ def split_format_sql(query: str, parameters: Sequence[ParameterType]) -> List[st
             raise NotSupportedError(
                 "formatting multistatement queries is not supported"
             )
-        return [format_statement(statements[0], parameters)]
+        return [format_statement(statements[0], paramset) for paramset in parameters]
     return [str(st).strip().rstrip(";") for st in statements]

--- a/src/firebolt/async_db/_types.py
+++ b/src/firebolt/async_db/_types.py
@@ -226,8 +226,7 @@ def format_value(value: ParameterType) -> str:
 
 def format_statement(statement: Statement, parameters: Sequence[ParameterType]) -> str:
     """
-    Substitute placeholders in queries with provided values.
-    '?' symbol is used as a placeholder. Using '\\?' would result in a plain '?'
+    Substitute placeholders in a sqlparse statement with provided values.
     """
     idx = 0
 
@@ -260,13 +259,14 @@ def format_statement(statement: Statement, parameters: Sequence[ParameterType]) 
     return formatted_sql
 
 
-def format_sql(query: str, parameters: Sequence[ParameterType]) -> str:
-    return format_statement(parse_sql(query)[0], parameters)
-
-
 def split_format_sql(
     query: str, parameters: Sequence[Sequence[ParameterType]]
 ) -> List[str]:
+    """
+    Split a query into separate statement, and format it with parameters
+    if it's a single statement
+    Trying to format a multi-statement query would result in NotSupportedError
+    """
     statements = parse_sql(query)
     if not statements:
         return [query]

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -201,7 +201,7 @@ class BaseCursor:
         self._row_sets.append(row_set)
         if self._next_set_idx == 0:
             # Populate values for first set
-            self.nextset()
+            self._pop_next_set()
 
     @check_not_closed
     @check_query_executed
@@ -211,6 +211,12 @@ class BaseCursor:
         from the current set.
         Returns True if operation was successful,
         None if there are no more sets to retrive
+        """
+        return self._pop_next_set()
+
+    def _pop_next_set(self) -> Optional[bool]:
+        """
+        Same functionality as .nextset, but doesn't check that query has been executed.
         """
         if self._next_set_idx >= len(self._row_sets):
             return None

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -175,19 +175,22 @@ class BaseCursor:
         # Empty response is returned for insert query
         if response.headers.get("content-length", "") == "0":
             row_set = (-1, None, None)
-        try:
-            query_data = response.json()
-            rowcount = int(query_data["rows"])
-            descriptions = [
-                Column(d["name"], parse_type(d["type"]), None, None, None, None, None)
-                for d in query_data["meta"]
-            ]
+        else:
+            try:
+                query_data = response.json()
+                rowcount = int(query_data["rows"])
+                descriptions = [
+                    Column(
+                        d["name"], parse_type(d["type"]), None, None, None, None, None
+                    )
+                    for d in query_data["meta"]
+                ]
 
-            # Parse data during fetch
-            rows = query_data["data"]
-            row_set = (rowcount, descriptions, rows)
-        except (KeyError, JSONDecodeError) as err:
-            raise DataError(f"Invalid query data format: {str(err)}")
+                # Parse data during fetch
+                rows = query_data["data"]
+                row_set = (rowcount, descriptions, rows)
+            except (KeyError, JSONDecodeError) as err:
+                raise DataError(f"Invalid query data format: {str(err)}")
 
         self._row_sets.append(row_set)
         if self._next_set_idx == 0:

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -195,7 +195,7 @@ class BaseCursor:
                 # Parse data during fetch
                 rows = query_data["data"]
                 row_set = (rowcount, descriptions, rows)
-            except (KeyError, JSONDecodeError) as err:
+            except (KeyError, JSONDecodeError, ValueError) as err:
                 raise DataError(f"Invalid query data format: {str(err)}")
 
         self._row_sets.append(row_set)
@@ -220,10 +220,9 @@ class BaseCursor:
         """
         if self._next_set_idx >= len(self._row_sets):
             return None
-        cur_set = self._row_sets[self._next_set_idx]
-        self._rowcount = cur_set[0]
-        self._descriptions = cur_set[1]
-        self._rows = cur_set[2]
+        self._rowcount, self._descriptions, self._rows = self._row_sets[
+            self._next_set_idx
+        ]
         self._next_set_idx += 1
         return True
 

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -6,7 +6,6 @@ import time
 from enum import Enum
 from functools import wraps
 from inspect import cleandoc
-from json import JSONDecodeError
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -195,7 +194,7 @@ class BaseCursor:
                 # Parse data during fetch
                 rows = query_data["data"]
                 row_set = (rowcount, descriptions, rows)
-            except (KeyError, JSONDecodeError, ValueError) as err:
+            except (KeyError, ValueError) as err:
                 raise DataError(f"Invalid query data format: {str(err)}")
 
         self._row_sets.append(row_set)

--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -259,7 +259,7 @@ async def test_multi_statement_query(connection: Connection) -> None:
         assert c.rowcount == -1, "Invalid row count"
         assert c.description is None, "Invalid description"
 
-        c.nextset()
+        assert c.nextset()
 
         assert c.rowcount == 2, "Invalid select row count"
         assert_deep_eq(
@@ -276,3 +276,5 @@ async def test_multi_statement_query(connection: Connection) -> None:
             [[1, "a"], [2, "b"]],
             "Invalid data in table after parameterized insert",
         )
+
+        assert c.nextset() is None

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -250,7 +250,7 @@ def test_multi_statement_query(connection: Connection) -> None:
         assert c.rowcount == -1, "Invalid row count"
         assert c.description is None, "Invalid description"
 
-        c.nextset()
+        assert c.nextset()
 
         assert c.rowcount == 2, "Invalid select row count"
         assert_deep_eq(
@@ -267,3 +267,5 @@ def test_multi_statement_query(connection: Connection) -> None:
             [[1, "a"], [2, "b"]],
             "Invalid data in table after parameterized insert",
         )
+
+        assert c.nextset() is None

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -229,3 +229,41 @@ def test_parameterized_query(connection: Connection) -> None:
             [params + ["?"]],
             "Invalid data in table after parameterized insert",
         )
+
+
+def test_multi_statement_query(connection: Connection) -> None:
+    """Query parameters are handled properly"""
+
+    with connection.cursor() as c:
+        c.execute("DROP TABLE IF EXISTS test_tb_multi_statement")
+        c.execute(
+            "CREATE FACT TABLE test_tb_multi_statement(i int, s string) primary index i"
+        )
+
+        assert (
+            c.execute(
+                "INSERT INTO test_tb_multi_statement values (1, 'a'), (2, 'b');"
+                "SELECT * FROM test_tb_multi_statement"
+            )
+            == -1
+        ), "Invalid row count returned for insert"
+        assert c.rowcount == -1, "Invalid row count"
+        assert c.description is None, "Invalid description"
+
+        c.nextset()
+
+        assert c.rowcount == 2, "Invalid select row count"
+        assert_deep_eq(
+            c.description,
+            [
+                Column("i", int, None, None, None, None, None),
+                Column("s", str, None, None, None, None, None),
+            ],
+            "Invalid select query description",
+        )
+
+        assert_deep_eq(
+            c.fetchall(),
+            [[1, "a"], [2, "b"]],
+            "Invalid data in table after parameterized insert",
+        )

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -64,10 +64,7 @@ async def test_closed_cursor(cursor: Cursor):
         ("fetchmany", ()),
         ("fetchall", ()),
     )
-    methods = (
-        "setinputsizes",
-        "setoutputsize",
-    )
+    methods = ("setinputsizes", "setoutputsize", "nextset")
 
     cursor.close()
 
@@ -117,6 +114,9 @@ async def test_cursor_no_query(
     for amethod in async_methods:
         with raises(QueryNotRunError):
             await getattr(cursor, amethod)()
+
+    with raises(QueryNotRunError):
+        await cursor.nextset()
 
     with raises(QueryNotRunError):
         [r async for r in cursor]

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -451,10 +451,12 @@ async def test_cursor_multi_statement(
             await cursor.fetchone() == python_query_data[i]
         ), f"Invalid data row at position {i}"
 
-    cursor.nextset()
+    assert cursor.nextset()
     assert cursor.rowcount == -1, "Invalid cursor row count"
     assert cursor.description is None, "Invalid cursor description"
     with raises(DataError) as exc_info:
         await cursor.fetchall()
 
     assert str(exc_info.value) == "no rows to fetch", "Invalid error message"
+
+    assert cursor.nextset() is None

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -13,7 +13,6 @@ from firebolt.common.exception import (
     DataError,
     EngineNotRunningError,
     FireboltDatabaseError,
-    NotSupportedError,
     OperationalError,
     QueryNotRunError,
 )
@@ -157,8 +156,8 @@ async def test_cursor_execute(
     """Cursor is able to execute query, all fields are populated properly."""
 
     for query in (
-        lambda: cursor.execute("select *"),
-        lambda: cursor.executemany("select *", [None]),
+        lambda: cursor.execute("select * from t"),
+        lambda: cursor.executemany("select * from t", []),
     ):
         # Query with json output
         httpx_mock.add_callback(auth_callback, url=auth_url)
@@ -202,7 +201,7 @@ async def test_cursor_execute_error(
     """Cursor handles all types of errors properly."""
     for query in (
         lambda: cursor.execute("select *"),
-        lambda: cursor.executemany("select *", [None]),
+        lambda: cursor.executemany("select *", []),
     ):
         httpx_mock.add_callback(auth_callback, url=auth_url)
 
@@ -427,5 +426,3 @@ async def test_set_parameters(
 @mark.asyncio
 async def test_cursor_multi_statement(cursor: Cursor):
     """executemany with multiple parameter sets is not supported"""
-    with raises(NotSupportedError):
-        await cursor.executemany("select ?", [(1,), (2,)])

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -424,5 +424,37 @@ async def test_set_parameters(
 
 
 @mark.asyncio
-async def test_cursor_multi_statement(cursor: Cursor):
+async def test_cursor_multi_statement(
+    httpx_mock: HTTPXMock,
+    auth_callback: Callable,
+    auth_url: str,
+    query_callback: Callable,
+    insert_query_callback: Callable,
+    query_url: str,
+    cursor: Cursor,
+    python_query_description: List[Column],
+    python_query_data: List[List[ColType]],
+):
     """executemany with multiple parameter sets is not supported"""
+    httpx_mock.add_callback(auth_callback, url=auth_url)
+    httpx_mock.add_callback(query_callback, url=query_url)
+    httpx_mock.add_callback(insert_query_callback, url=query_url)
+
+    rc = await cursor.execute("select * from t; insert into t values (1, 2)")
+    assert rc == len(python_query_data), "Invalid row count returned"
+    assert cursor.rowcount == len(python_query_data), "Invalid cursor row count"
+    for i, (desc, exp) in enumerate(zip(cursor.description, python_query_description)):
+        assert desc == exp, f"Invalid column description at position {i}"
+
+    for i in range(cursor.rowcount):
+        assert (
+            await cursor.fetchone() == python_query_data[i]
+        ), f"Invalid data row at position {i}"
+
+    cursor.nextset()
+    assert cursor.rowcount == -1, "Invalid cursor row count"
+    assert cursor.description is None, "Invalid cursor description"
+    with raises(DataError) as exc_info:
+        await cursor.fetchall()
+
+    assert str(exc_info.value) == "no rows to fetch", "Invalid error message"

--- a/tests/unit/async_db/test_typing_format.py
+++ b/tests/unit/async_db/test_typing_format.py
@@ -113,8 +113,8 @@ def test_format_statement_errors() -> None:
         ("", (), [""]),
         ("select * from t", (), ["select * from t"]),
         ("select * from t;", (), ["select * from t"]),
-        ("select * from t where id == ?", (1,), ["select * from t where id == 1"]),
-        ("select * from t where id == ?;", (1,), ["select * from t where id == 1"]),
+        ("select * from t where id == ?", ((1,),), ["select * from t where id == 1"]),
+        ("select * from t where id == ?;", ((1,),), ["select * from t where id == 1"]),
         (
             "select * from t;insert into t values (1, 2)",
             (),
@@ -124,6 +124,11 @@ def test_format_statement_errors() -> None:
             "insert into t values (1, 2);select * from t;",
             (),
             ["insert into t values (1, 2)", "select * from t"],
+        ),
+        (
+            "select * from t where id == ?",
+            ((1,), (2,)),
+            ["select * from t where id == 1", "select * from t where id == 2"],
         ),
     ],
 )
@@ -136,7 +141,7 @@ def test_split_format_sql(query: str, params: tuple, result: List[str]) -> None:
 def test_split_format_error() -> None:
     with raises(NotSupportedError) as exc_info:
         split_format_sql(
-            "select * from t where id == ?; insert into t values (?, ?)", (1, 2, 3)
+            "select * from t where id == ?; insert into t values (?, ?)", ((1, 2, 3),)
         )
 
     assert (

--- a/tests/unit/async_db/test_typing_format.py
+++ b/tests/unit/async_db/test_typing_format.py
@@ -1,9 +1,11 @@
 from datetime import date, datetime, timedelta, timezone
 
 from pytest import mark, raises
+from sqlparse import parse
+from sqlparse.sql import Statement
 
 from firebolt.async_db import DataError
-from firebolt.async_db._types import format_sql, format_value
+from firebolt.async_db._types import format_statement, format_value
 
 
 @mark.parametrize(
@@ -45,52 +47,55 @@ def test_format_value_errors() -> None:
     assert str(exc_info.value) == "unsupported parameter type <class 'Exception'>"
 
 
+def to_statement(sql: str) -> Statement:
+    return parse(sql)[0]
+
+
 @mark.parametrize(
-    "sql,params,result",
+    "statement,params,result",
     [
-        ("", (), ""),
-        ("select * from table", (), "select * from table"),
+        (to_statement("select * from table"), (), "select * from table"),
         (
-            "select * from table where id == ?",
+            to_statement("select * from table where id == ?"),
             (1,),
             "select * from table where id == 1",
         ),
         (
-            "select * from table where id == '?'",
+            to_statement("select * from table where id == '?'"),
             (),
             "select * from table where id == '?'",
         ),
         (
-            "insert into table values (?, ?, '?')",
+            to_statement("insert into table values (?, ?, '?')"),
             (1, "1"),
             "insert into table values (1, '1', '?')",
         ),
         (
-            "select * from t where /*comment ?*/ id == ?",
+            to_statement("select * from t where /*comment ?*/ id == ?"),
             ("*/ 1 == 1 or /*",),
             "select * from t where /*comment ?*/ id == '*/ 1 == 1 or /*'",
         ),
         (
-            "select * from t where id == ?",
+            to_statement("select * from t where id == ?"),
             ("' or '' == '",),
             r"select * from t where id == '\' or \'\' == \''",
         ),
     ],
 )
-def test_format_sql(sql: str, params: tuple, result: str) -> None:
-    assert format_sql(sql, params) == result, "Invalid format sql result"
+def test_format_statement(statement: Statement, params: tuple, result: str) -> None:
+    assert format_statement(statement, params) == result, "Invalid format sql result"
 
 
-def test_format_sql_errors() -> None:
+def test_format_statement_errors() -> None:
     with raises(DataError) as exc_info:
-        format_sql("?", [])
+        format_statement(to_statement("?"), [])
     assert (
         str(exc_info.value)
         == "not enough parameters provided for substitution: given 0, found one more"
     ), "Invalid not enought parameters error"
 
     with raises(DataError) as exc_info:
-        format_sql("?", (1, 2))
+        format_statement(to_statement("?"), (1, 2))
     assert (
         str(exc_info.value)
         == "too many parameters provided for substitution: given 2, used only 1"

--- a/tests/unit/db/test_cursor.py
+++ b/tests/unit/db/test_cursor.py
@@ -9,7 +9,6 @@ from firebolt.async_db.cursor import ColType, Column, CursorState
 from firebolt.common.exception import (
     CursorClosedError,
     DataError,
-    NotSupportedError,
     OperationalError,
     QueryNotRunError,
 )
@@ -145,7 +144,7 @@ def test_cursor_execute(
 
     for query in (
         lambda: cursor.execute("select *"),
-        lambda: cursor.executemany("select *", [None]),
+        lambda: cursor.executemany("select *", []),
     ):
         # Query with json output
         httpx_mock.add_callback(auth_callback, url=auth_url)
@@ -184,7 +183,7 @@ def test_cursor_execute_error(
     """Cursor handles all types of errors properly."""
     for query in (
         lambda: cursor.execute("select *"),
-        lambda: cursor.executemany("select *", [None]),
+        lambda: cursor.executemany("select *", []),
     ):
         httpx_mock.add_callback(auth_callback, url=auth_url)
 
@@ -372,5 +371,3 @@ def test_set_parameters(
 
 def test_cursor_multi_statement(cursor: Cursor):
     """executemany with multiple parameter sets is not supported"""
-    with raises(NotSupportedError):
-        cursor.executemany("select ?", [(1,), (2,)])

--- a/tests/unit/db/test_cursor.py
+++ b/tests/unit/db/test_cursor.py
@@ -396,10 +396,12 @@ def test_cursor_multi_statement(
             cursor.fetchone() == python_query_data[i]
         ), f"Invalid data row at position {i}"
 
-    cursor.nextset()
+    assert cursor.nextset()
     assert cursor.rowcount == -1, "Invalid cursor row count"
     assert cursor.description is None, "Invalid cursor description"
     with raises(DataError) as exc_info:
         cursor.fetchall()
 
     assert str(exc_info.value) == "no rows to fetch", "Invalid error message"
+
+    assert cursor.nextset() is None

--- a/tests/unit/db/test_cursor.py
+++ b/tests/unit/db/test_cursor.py
@@ -60,6 +60,7 @@ def test_closed_cursor(cursor: Cursor):
         ("fetchall", ()),
         ("setinputsizes", (cursor, [0])),
         ("setoutputsize", (cursor, 0)),
+        ("nextset", (cursor, [])),
     )
 
     cursor.close()
@@ -97,6 +98,7 @@ def test_cursor_no_query(
         "fetchone",
         "fetchmany",
         "fetchall",
+        "nextset",
     )
 
     httpx_mock.add_callback(auth_callback, url=auth_url)


### PR DESCRIPTION
Implemented multi-statement queries functionality based on the design
https://docs.google.com/document/d/13O5jHFjnvRrNSvzBXNohYYz4ChI1jhi_7xyIwd1_7Xs/edit
- Added `nextset` method from PEP249 to be able to move to next result set
- Set `cursor.state` to new `CursorState.ERROR` value if error occured during query execution. This allows to figure out if all queries have passed in case of multi-statement, and is more verbose in my opinion
Added unit and integration tests