### PR TITLE
chore: Bump httpx to 0.21.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 install_requires =
     aiorwlock==1.1.0
     async-property==0.2.1
-    httpx[http2]==0.19.0
+    httpx[http2]==0.21.3
     pydantic[dotenv]==1.8.2
     readerwriterlock==1.0.9
     sqlparse>=0.4.2
@@ -47,7 +47,7 @@ dev =
     pytest==6.2.5
     pytest-asyncio
     pytest-cov==3.0.0
-    pytest-httpx==0.13.0
+    pytest-httpx==0.18.0
     pytest-mock==3.6.1
 
 [options.package_data]

--- a/tests/unit/async_db/conftest.py
+++ b/tests/unit/async_db/conftest.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, List
 
 from httpx import URL, Request, Response, codes
 from pytest import fixture
-from pytest_httpx import to_response
 
 from firebolt.async_db import ARRAY, Connection, Cursor, connect
 from firebolt.async_db.cursor import JSON_OUTPUT_FORMAT, ColType, Column
@@ -115,7 +114,7 @@ def query_callback(
                 "scanned_bytes_storage": 0,
             },
         }
-        return to_response(status_code=codes.OK, json=query_response)
+        return Response(status_code=codes.OK, json=query_response)
 
     return do_query
 
@@ -147,7 +146,7 @@ def query_with_params_callback(
                 "scanned_bytes_storage": 0,
             },
         }
-        return to_response(status_code=codes.OK, json=query_response)
+        return Response(status_code=codes.OK, json=query_response)
 
     return do_query
 
@@ -157,7 +156,7 @@ def insert_query_callback(
     query_description: List[Column], query_data: List[List[ColType]]
 ) -> Callable:
     def do_query(request: Request, **kwargs) -> Response:
-        return to_response(status_code=codes.OK, headers={"content-length": "0"})
+        return Response(status_code=codes.OK, headers={"content-length": "0"})
 
     return do_query
 
@@ -174,7 +173,7 @@ def set_params() -> Dict:
 @fixture
 def query_url(settings: Settings, db_name: str) -> str:
     return URL(
-        f"https://{settings.server}?database={db_name}"
+        f"https://{settings.server}/?database={db_name}"
         f"&output_format={JSON_OUTPUT_FORMAT}"
     )
 

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -197,7 +197,7 @@ async def test_cursor_execute_error(
         httpx_mock.add_callback(auth_callback, url=auth_url)
 
         # Internal httpx error
-        def http_error(**kwargs):
+        def http_error(*args, **kwargs):
             raise StreamError("httpx error")
 
         httpx_mock.add_callback(http_error, url=query_url)
@@ -217,7 +217,7 @@ async def test_cursor_execute_error(
         # Database query error
         httpx_mock.add_response(
             status_code=codes.INTERNAL_SERVER_ERROR,
-            data="Query error message",
+            content="Query error message",
             url=query_url,
         )
         with raises(OperationalError) as excinfo:
@@ -230,7 +230,7 @@ async def test_cursor_execute_error(
         # Database does not exist error
         httpx_mock.add_response(
             status_code=codes.FORBIDDEN,
-            data="Query error message",
+            content="Query error message",
             url=query_url,
         )
         httpx_mock.add_response(
@@ -243,7 +243,7 @@ async def test_cursor_execute_error(
         # Engine is not running error
         httpx_mock.add_response(
             status_code=codes.SERVICE_UNAVAILABLE,
-            data="Query error message",
+            content="Query error message",
             url=query_url,
         )
         httpx_mock.add_response(

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -3,8 +3,7 @@ import typing
 
 import httpx
 import pytest
-from pytest_httpx import to_response
-from pytest_httpx._httpx_internals import Response
+from httpx import Response
 
 
 @pytest.fixture
@@ -42,7 +41,7 @@ def check_credentials_callback(
         assert "password" in body, "Missing password"
         assert body["password"] == test_password, "Invalid password"
 
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"expires_in": 2 ** 32, "access_token": test_token},
         )
@@ -61,6 +60,6 @@ def check_token_callback(test_token: str) -> typing.Callable:
         token = auth[len(prefix) :]
         assert token == test_token, "invalid authorization token"
 
-        return to_response(status_code=httpx.codes.OK)
+        return Response(status_code=httpx.codes.OK)
 
     return check_token

--- a/tests/unit/client/test_auth.py
+++ b/tests/unit/client/test_auth.py
@@ -99,7 +99,7 @@ def test_auth_error_handling(httpx_mock: HTTPXMock):
         auth = Auth("user", "password", api_endpoint=api_endpoint)
 
         # Internal httpx error
-        def http_error(**kwargs):
+        def http_error(*args, **kwargs):
             raise StreamError("httpx")
 
         httpx_mock.add_callback(http_error)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,9 +2,8 @@ from typing import Callable, List
 
 import httpx
 import pytest
+from httpx import Response
 from pydantic import SecretStr
-from pytest_httpx import to_response
-from pytest_httpx._httpx_internals import Response
 
 from firebolt.common.exception import (
     DatabaseError,
@@ -106,7 +105,7 @@ def auth_callback(auth_url: str) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == auth_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"access_token": "", "expires_in": 2 ** 32},
         )
@@ -150,11 +149,11 @@ def account_id_callback(
     ) -> Response:
         assert request.url == account_id_url
         if account_id_url.endswith(ACCOUNT_URL):  # account_name shouldn't be specified.
-            return to_response(
+            return Response(
                 status_code=httpx.codes.OK, json={"account": {"id": account_id}}
             )
         # In this case, an account_name *should* be specified.
-        return to_response(status_code=httpx.codes.OK, json={"account_id": account_id})
+        return Response(status_code=httpx.codes.OK, json={"account_id": account_id})
 
     return do_mock
 
@@ -180,7 +179,7 @@ def get_engine_callback(
         **kwargs,
     ) -> Response:
         assert request.url == get_engine_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={
                 "engine": {
@@ -216,7 +215,7 @@ def get_providers_callback(get_providers_url: str, provider: Provider) -> Callab
         **kwargs,
     ) -> Response:
         assert request.url == get_providers_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json=list_to_paginated_response([provider]),
         )

--- a/tests/unit/db/conftest.py
+++ b/tests/unit/db/conftest.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, List
 
 from httpx import URL, Request, Response, codes
 from pytest import fixture
-from pytest_httpx import to_response
 
 from firebolt.async_db.cursor import JSON_OUTPUT_FORMAT, ColType, Column
 from firebolt.common.settings import Settings
@@ -115,7 +114,7 @@ def query_callback(
                 "scanned_bytes_storage": 0,
             },
         }
-        return to_response(status_code=codes.OK, json=query_response)
+        return Response(status_code=codes.OK, json=query_response)
 
     return do_query
 
@@ -147,7 +146,7 @@ def query_with_params_callback(
                 "scanned_bytes_storage": 0,
             },
         }
-        return to_response(status_code=codes.OK, json=query_response)
+        return Response(status_code=codes.OK, json=query_response)
 
     return do_query
 
@@ -157,7 +156,7 @@ def insert_query_callback(
     query_description: List[Column], query_data: List[List[ColType]]
 ) -> Callable:
     def do_query(request: Request, **kwargs) -> Response:
-        return to_response(status_code=codes.OK, headers={"content-length": "0"})
+        return Response(status_code=codes.OK, headers={"content-length": "0"})
 
     return do_query
 
@@ -174,7 +173,7 @@ def set_params() -> Dict:
 @fixture
 def query_url(settings: Settings, db_name: str) -> str:
     return URL(
-        f"https://{settings.server}?database={db_name}"
+        f"https://{settings.server}/?database={db_name}"
         f"&output_format={JSON_OUTPUT_FORMAT}"
     )
 

--- a/tests/unit/db/test_cursor.py
+++ b/tests/unit/db/test_cursor.py
@@ -179,7 +179,7 @@ def test_cursor_execute_error(
         httpx_mock.add_callback(auth_callback, url=auth_url)
 
         # Internal httpx error
-        def http_error(**kwargs):
+        def http_error(*args, **kwargs):
             raise StreamError("httpx error")
 
         httpx_mock.add_callback(http_error, url=query_url)
@@ -199,7 +199,7 @@ def test_cursor_execute_error(
         # Database query error
         httpx_mock.add_response(
             status_code=codes.INTERNAL_SERVER_ERROR,
-            data="Query error message",
+            content="Query error message",
             url=query_url,
         )
         with raises(OperationalError) as excinfo:

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -3,8 +3,7 @@ from typing import Callable, List
 
 import httpx
 import pytest
-from pytest_httpx import to_response
-from pytest_httpx._httpx_internals import Response
+from httpx import Response
 
 from firebolt.common.settings import Settings
 from firebolt.common.urls import (
@@ -83,7 +82,7 @@ def provider_callback(provider_url: str, mock_providers) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == provider_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json=list_to_paginated_response(mock_providers),
         )
@@ -103,7 +102,7 @@ def region_callback(region_url: str, mock_regions) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == region_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json=list_to_paginated_response(mock_regions),
         )
@@ -123,7 +122,7 @@ def instance_type_callback(instance_type_url: str, mock_instance_types) -> Calla
         **kwargs,
     ) -> Response:
         assert request.url == instance_type_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json=list_to_paginated_response(mock_instance_types),
         )
@@ -143,7 +142,7 @@ def engine_callback(engine_url: str, mock_engine) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == engine_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"engine": mock_engine.dict()},
         )
@@ -165,7 +164,7 @@ def account_engine_callback(engine_url: str, mock_engine) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == account_engine_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"engine": mock_engine.dict()},
         )
@@ -205,7 +204,7 @@ def create_databases_callback(databases_url: str, mock_database) -> Callable:
         mock_database.description = database_properties["description"]
 
         assert request.url == databases_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"database": mock_database.dict()},
         )
@@ -218,7 +217,7 @@ def databases_get_callback(databases_url: str, mock_database) -> Callable:
     def get_databases_callback_inner(
         request: httpx.Request = None, **kwargs
     ) -> Response:
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK, json={"edges": [{"node": mock_database.dict()}]}
         )
 
@@ -239,7 +238,7 @@ def database_callback(database_url: str, mock_database) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == database_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"database": mock_database.dict()},
         )
@@ -254,7 +253,7 @@ def database_not_found_callback(database_url: str) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == database_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={},
         )
@@ -276,7 +275,7 @@ def database_get_by_name_callback(database_get_by_name_url, mock_database) -> Ca
         **kwargs,
     ) -> Response:
         assert request.url == database_get_by_name_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"database_id": {"database_id": mock_database.database_id}},
         )
@@ -300,7 +299,7 @@ def database_get_callback(database_get_url, mock_database) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == database_get_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"database": mock_database.dict()},
         )
@@ -335,7 +334,7 @@ def bindings_callback(bindings_url: str, binding: Binding) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == bindings_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json=list_to_paginated_response([binding]),
         )
@@ -350,7 +349,7 @@ def no_bindings_callback(bindings_url: str) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == bindings_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json=list_to_paginated_response([]),
         )
@@ -374,7 +373,7 @@ def create_binding_callback(create_binding_url: str, binding) -> Callable:
         **kwargs,
     ) -> Response:
         assert request.url == create_binding_url
-        return to_response(
+        return Response(
             status_code=httpx.codes.OK,
             json={"binding": binding.dict()},
         )


### PR DESCRIPTION
Upgrading `httpx` to the latest version. `pytest-httpx` also needed to be updated. API has changed slightly between those versions, most notably `to_response` is deprecated in favour of `httpx.Response` also pytest-httpx no longer accepts as equal  `<url>/?database=<db>` and `<url>?database=<db>`.
From quick research looks like slash first is generally accepted so I modified `query_url` mock to reflect that. This does not affect the actual execution (confirmed in integration testing) and is purely mock-related.

This PR is a prerequisite to fixing the TCP timeout.