### PR TITLE
fix: Jupyter runtime

### DIFF
--- a/examples/dbapi.ipynb
+++ b/examples/dbapi.ipynb
@@ -37,15 +37,14 @@
    "source": [
     "# Only one of these two parameters should be specified\n",
     "engine_url = \"\"\n",
-    "engine_name = \"sburlakov_test_integration\"\n",
     "assert bool(engine_url) != bool(\n",
     "    engine_name\n",
     "), \"Specify only one of engine_name and engine_url\"\n",
     "\n",
-    "database_name = \"sburlakov_test\"\n",
-    "username = \"stepan.burlakov@firebolt.io\"\n",
-    "password = \"Not55566\"\n",
-    "api_endpoint = \"api.dev.firebolt.io\"  # DEFAULT_API_URL"
+    "database_name = \"\"\n",
+    "username = \"\"\n",
+    "password = \"\"\n",
+    "api_endpoint = DEFAULT_API_URL"
    ]
   },
   {

--- a/examples/dbapi.ipynb
+++ b/examples/dbapi.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bdd3e404",
    "metadata": {},
    "outputs": [],
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "0ce8b2d3",
    "metadata": {},
    "outputs": [],
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "646869f7",
    "metadata": {},
    "outputs": [],

--- a/examples/dbapi.ipynb
+++ b/examples/dbapi.ipynb
@@ -10,13 +10,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "bdd3e404",
    "metadata": {},
    "outputs": [],
    "source": [
     "from firebolt.db import connect\n",
-    "from firebolt.client import DEFAULT_API_URL"
+    "from firebolt.client import DEFAULT_API_URL\n",
+    "from datetime import datetime"
    ]
   },
   {
@@ -29,22 +30,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "0ce8b2d3",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Only one of these two parameters should be specified\n",
     "engine_url = \"\"\n",
-    "engine_name = \"\"\n",
+    "engine_name = \"sburlakov_test_integration\"\n",
     "assert bool(engine_url) != bool(\n",
     "    engine_name\n",
     "), \"Specify only one of engine_name and engine_url\"\n",
     "\n",
-    "database_name = \"\"\n",
-    "username = \"\"\n",
-    "password = \"\"\n",
-    "api_endpoint = DEFAULT_API_URL"
+    "database_name = \"sburlakov_test\"\n",
+    "username = \"stepan.burlakov@firebolt.io\"\n",
+    "password = \"Not55566\"\n",
+    "api_endpoint = \"api.dev.firebolt.io\"  # DEFAULT_API_URL"
    ]
   },
   {
@@ -57,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "646869f7",
    "metadata": {},
    "outputs": [],
@@ -98,8 +99,32 @@
     "    \"insert into test_table values (1, 'hello', '2021-01-01 01:01:01'),\"\n",
     "    \"(2, 'world', '2022-02-02 02:02:02'),\"\n",
     "    \"(3, '!', '2023-03-03 03:03:03')\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b356295a",
+   "metadata": {},
+   "source": [
+    "### Parameterized query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "929f5221",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(\n",
+    "    \"insert into test_table values (?, ?, ?)\",\n",
+    "    (3, \"single parameter set\", datetime.now()),\n",
     ")\n",
-    "cursor.execute(\"select * from test_table\")"
+    "cursor.executemany(\n",
+    "    \"insert into test_table values (?, ?, ?)\",\n",
+    "    ((4, \"multiple\", datetime.now()), (5, \"parameter sets\", datetime.fromtimestamp(0))),\n",
+    ")"
    ]
   },
   {
@@ -117,6 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "cursor.execute(\"select * from test_table\")\n",
     "print(\"Description: \", cursor.description)\n",
     "print(\"Rowcount: \", cursor.rowcount)"
    ]
@@ -139,6 +165,67 @@
     "print(cursor.fetchone())\n",
     "print(cursor.fetchmany(1))\n",
     "print(cursor.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efc4ff0a",
+   "metadata": {},
+   "source": [
+    "## Multi-statement queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "744817b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(\n",
+    "    \"\"\"\n",
+    "    select * from test_table where id < 4;\n",
+    "    select * from test_table where id > 2;\n",
+    "\"\"\"\n",
+    ")\n",
+    "print(cursor._row_sets[0][2])\n",
+    "print(cursor._row_sets[1][2])\n",
+    "print(cursor._rows)\n",
+    "# print(\"First query: \", cursor.fetchall())\n",
+    "assert cursor.nextset()\n",
+    "print(cursor._rows)\n",
+    "# print(\"Secont query: \", cursor.fetchall())\n",
+    "assert cursor.nextset() is None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02e5db2f",
+   "metadata": {},
+   "source": [
+    "### Error handling\n",
+    "If one query fails during the execution, all remaining queries are canceled.\n",
+    "However, you still can fetch results for successful queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "888500a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    cursor.execute(\n",
+    "        \"\"\"\n",
+    "        select * from test_table where id < 4;\n",
+    "        select * from test_table where wrong_field > 2;\n",
+    "        select * from test_table\n",
+    "    \"\"\"\n",
+    "    )\n",
+    "except:\n",
+    "    pass\n",
+    "cursor.fetchall()"
    ]
   },
   {
@@ -285,6 +372,38 @@
    "outputs": [],
    "source": [
     "await print_results(async_cursor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da36dd3f",
+   "metadata": {},
+   "source": [
+    "### Closing connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83fc1686",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# manually\n",
+    "connection.close()\n",
+    "\n",
+    "# using context manager\n",
+    "with connect(\n",
+    "    engine_url=engine_url,\n",
+    "    engine_name=engine_name,\n",
+    "    database=database_name,\n",
+    "    username=username,\n",
+    "    password=password,\n",
+    "    api_endpoint=api_endpoint,\n",
+    ") as conn:\n",
+    "    # create cursors, perform database queries\n",
+    "    pass\n",
+    "conn.closed"
    ]
   }
  ],

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import socket
 from json import JSONDecodeError
 from types import TracebackType
-from typing import Callable, List, Optional, Type
+from typing import Any, Callable, List, Optional, Type
 
 from httpcore.backends.auto import AutoBackend
 from httpcore.backends.base import AsyncNetworkStream
@@ -207,7 +207,7 @@ class BaseConnection:
         self._cursors: List[BaseCursor] = []
         self._is_closed = False
 
-    def cursor(self) -> BaseCursor:
+    def _cursor(self, **kwargs: Any) -> BaseCursor:
         """
         Create new cursor object.
         """
@@ -215,7 +215,7 @@ class BaseConnection:
         if self.closed:
             raise ConnectionClosedError("Unable to create cursor: connection closed")
 
-        c = self.cursor_class(self._client, self)
+        c = self.cursor_class(self._client, self, **kwargs)
         self._cursors.append(c)
         return c
 
@@ -279,7 +279,7 @@ class Connection(BaseConnection):
     aclose = BaseConnection._aclose
 
     def cursor(self) -> Cursor:
-        c = super().cursor()
+        c = super()._cursor()
         assert isinstance(c, Cursor)  # typecheck
         return c
 

--- a/src/firebolt/common/util.py
+++ b/src/firebolt/common/util.py
@@ -55,6 +55,8 @@ class AsyncJobThread:
     """
     Thread runner that allows running async tasks syncronously in a separate thread.
     Caches loop to be reused in all threads
+    It allows running async functions syncronously inside a running event loop.
+    Since nesting loops is not allowed, we create a separate thread for a new event loop
     """
 
     def __init__(self) -> None:

--- a/src/firebolt/common/util.py
+++ b/src/firebolt/common/util.py
@@ -67,6 +67,7 @@ class AsyncJobThread:
     def _initialize_loop(self) -> None:
         if not self.loop:
             try:
+                # despite the docs, this function fails if no loop is set
                 self.loop = get_event_loop()
             except RuntimeError:
                 self.loop = new_event_loop()

--- a/src/firebolt/common/util.py
+++ b/src/firebolt/common/util.py
@@ -1,6 +1,20 @@
-from asyncio import get_event_loop, new_event_loop, set_event_loop
+from asyncio import (
+    AbstractEventLoop,
+    get_event_loop,
+    new_event_loop,
+    set_event_loop,
+)
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Any, Callable, Type, TypeVar
+from threading import Thread
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Optional,
+    Type,
+    TypeVar,
+)
 
 T = TypeVar("T")
 
@@ -37,7 +51,39 @@ def fix_url_schema(url: str) -> str:
     return url if url.startswith("http") else f"https://{url}"
 
 
-def async_to_sync(f: Callable) -> Callable:
+class AsyncJobThread:
+    def __init__(self) -> None:
+        self.loop: Optional[AbstractEventLoop] = None
+        self.result: Optional[Any] = None
+        self.exception: Optional[BaseException] = None
+        super().__init__()
+
+    def _initialize_loop(self) -> None:
+        if not self.loop:
+            try:
+                self.loop = get_event_loop()
+            except RuntimeError:
+                self.loop = new_event_loop()
+        set_event_loop(self.loop)
+
+    def run(self, coro: Coroutine) -> None:
+        try:
+            self._initialize_loop()
+            assert self.loop is not None
+            self.result = self.loop.run_until_complete(coro)
+        except BaseException as e:
+            self.exception = e
+
+    def execute(self, coro: Coroutine) -> Any:
+        thread = Thread(target=self.run, args=[coro])
+        thread.start()
+        thread.join()
+        if self.exception:
+            raise self.exception
+        return self.result
+
+
+def async_to_sync(f: Callable, async_job_thread: AsyncJobThread = None) -> Callable:
     @wraps(f)
     def sync(*args: Any, **kwargs: Any) -> Any:
         try:
@@ -45,7 +91,12 @@ def async_to_sync(f: Callable) -> Callable:
         except RuntimeError:
             loop = new_event_loop()
             set_event_loop(loop)
-        res = loop.run_until_complete(f(*args, **kwargs))
-        return res
+        # We are inside a running loop
+        if loop.is_running():
+            nonlocal async_job_thread
+            if not async_job_thread:
+                async_job_thread = AsyncJobThread()
+            return async_job_thread.execute(f(*args, **kwargs))
+        return loop.run_until_complete(f(*args, **kwargs))
 
     return sync

--- a/src/firebolt/common/util.py
+++ b/src/firebolt/common/util.py
@@ -52,11 +52,15 @@ def fix_url_schema(url: str) -> str:
 
 
 class AsyncJobThread:
+    """
+    Thread runner that allows running async tasks syncronously in a separate thread.
+    Caches loop to be reused in all threads
+    """
+
     def __init__(self) -> None:
         self.loop: Optional[AbstractEventLoop] = None
         self.result: Optional[Any] = None
         self.exception: Optional[BaseException] = None
-        super().__init__()
 
     def _initialize_loop(self) -> None:
         if not self.loop:

--- a/tests/unit/common/test_util.py
+++ b/tests/unit/common/test_util.py
@@ -1,7 +1,7 @@
 from asyncio import run
 from threading import Thread
 
-from pytest import raises
+from pytest import mark, raises
 
 from firebolt.common.util import async_to_sync
 
@@ -47,6 +47,23 @@ def test_async_to_sync_after_run():
         run(task())
 
     # Here local event loop is closed by run
+
+    with raises(JobMarker):
+        async_to_sync(task)()
+
+
+@mark.asyncio
+async def test_nested_loops() -> None:
+    """async_to_sync properly works inside a running loop"""
+
+    class JobMarker(Exception):
+        pass
+
+    async def task():
+        raise JobMarker()
+
+    with raises(JobMarker):
+        await task()
 
     with raises(JobMarker):
         async_to_sync(task)()


### PR DESCRIPTION
Fixed jupyter notebook async issues, extended dbapi jupyter examples.
This fix also add's an ability to use sync connection and cursor inside an asyncio loop, which we didn't support previously.
The issue was that basically loops can't be nested in asyncio, and all jupyter code is run inside a loop. The workaround for this is to create a thread inside a running loop and use new loop there. One problem is that a single `httpx.AsyncClient` should use the same loop always, so connection needs to cache it, which is done by storing `AsyncJobThread`