### PR TITLE
ci: Specifying timeout method

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,5 +45,5 @@ jobs:
           API_ENDPOINT: "api.dev.firebolt.io"
           ACCOUNT_NAME: "firebolt"
         run: |
-          pytest -n 6 -o log_cli=true -o log_cli_level=INFO tests/integration
+          pytest -n 6 --timeout_method "signal" -o log_cli=true -o log_cli_level=INFO tests/integration
         

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,5 +54,5 @@ jobs:
           ACCOUNT_NAME: "firebolt"
           API_ENDPOINT: "api.dev.firebolt.io"
         run: |
-          pytest -o log_cli=true -o log_cli_level=INFO tests/integration
+          pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=INFO tests/integration
         

--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -66,7 +66,7 @@ async def test_select(
 
 
 @mark.asyncio
-@mark.timeout(timeout=400, method="signal")
+@mark.timeout(timeout=400)
 async def test_long_query(
     connection: Connection,
 ) -> None:

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -62,7 +62,7 @@ def test_select(
         )
 
 
-@mark.timeout(timeout=400, method="signal")
+@mark.timeout(timeout=400)
 def test_long_query(
     connection: Connection,
 ) -> None:


### PR DESCRIPTION
On Windows pytest-timeout does not support `signal` termination method so it fails our nightly jobs.
However, the other alternative is `thread` which does not play nicely with pytest-xdist which allows us to multithread our integration testing.
As a solution this sets signal for integration tests run on ubuntu and thread on nightly runs, which don't need to be fast.