### PR TITLE
feat(FIR-10892): Internal args for engine

### DIFF
--- a/src/firebolt/model/engine.py
+++ b/src/firebolt/model/engine.py
@@ -69,6 +69,7 @@ class EngineSettings(FireboltBaseModel):
         engine_type: EngineType = EngineType.GENERAL_PURPOSE,
         auto_stop_delay_duration: str = "1200s",
         warm_up: WarmupMethod = WarmupMethod.PRELOAD_INDEXES,
+        minimum_logging_level: str = "ENGINE_SETTINGS_LOGGING_LEVEL_INFO",
     ) -> EngineSettings:
         if engine_type == EngineType.GENERAL_PURPOSE:
             preset = engine_type.GENERAL_PURPOSE.api_settings_preset_name  # type: ignore # noqa: E501
@@ -80,7 +81,7 @@ class EngineSettings(FireboltBaseModel):
         return cls(
             preset=preset,
             auto_stop_delay_duration=auto_stop_delay_duration,
-            minimum_logging_level="ENGINE_SETTINGS_LOGGING_LEVEL_INFO",
+            minimum_logging_level=minimum_logging_level,
             is_read_only=is_read_only,
             warm_up=warm_up.api_name,
         )
@@ -459,3 +460,11 @@ class Engine(FireboltBaseModel):
         return Engine.parse_obj_with_service(
             obj=response.json()["engine"], engine_service=self._service
         )
+
+
+class _EngineCreateRequest(FireboltBaseModel):
+    """Helper model for sending Engine create requests."""
+
+    account_id: str
+    engine: Engine
+    engine_revision: Optional[EngineRevision]

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -22,6 +22,10 @@ from firebolt.common.urls import (
 from firebolt.model.binding import Binding, BindingKey
 from firebolt.model.database import Database, DatabaseKey
 from firebolt.model.engine import Engine, EngineKey, EngineSettings
+from firebolt.model.engine_revision import (
+    EngineRevision,
+    EngineRevisionSpecification,
+)
 from firebolt.model.instance_type import InstanceType, InstanceTypeKey
 from firebolt.model.region import Region
 from tests.unit.util import list_to_paginated_response
@@ -30,6 +34,11 @@ from tests.unit.util import list_to_paginated_response
 @pytest.fixture
 def engine_name() -> str:
     return "my_engine"
+
+
+@pytest.fixture
+def engine_scale() -> int:
+    return 2
 
 
 @pytest.fixture
@@ -46,6 +55,22 @@ def mock_engine(engine_name, region_1, engine_settings, account_id, settings) ->
         key=EngineKey(account_id=account_id, engine_id="mock_engine_id_1"),
         endpoint=f"https://{settings.server}",
     )
+
+
+@pytest.fixture
+def mock_engine_revision_spec(
+    instance_type_2, engine_scale
+) -> EngineRevisionSpecification:
+    return EngineRevisionSpecification(
+        db_compute_instances_type_key=instance_type_2.key,
+        db_compute_instances_count=engine_scale,
+        proxy_instances_type_key=instance_type_2.key,
+    )
+
+
+@pytest.fixture
+def mock_engine_revision(mock_engine_revision_spec) -> EngineRevision:
+    return EngineRevision(specification=mock_engine_revision_spec)
 
 
 @pytest.fixture


### PR DESCRIPTION
Allowing special parameters like `db_version`, `proxy_version` which are part of the API, but should be obfuscated from the external user. As discussed we're fine if users find out about them via reading the code, but reading the docs should not give hints about their existence.
This will mainly be used for automated testing by internal teams.