### PR TITLE
ci: No Fossa run on forks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,6 +18,7 @@ jobs:
     uses: firebolt-db/firebolt-python-sdk/.github/workflows/unit-tests.yml@main
   security-scan:
     needs: [unit-tests]
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: firebolt-db/firebolt-python-sdk/.github/workflows/security-scan.yml@main
     secrets:
       FOSSA_TOKEN: ${{ secrets.FOSSA_TOKEN }}


### PR DESCRIPTION
Due to the security limitations in GitHub Actions secrets are not available on Actions run when a pull request from a public fork is made. For now our best option is to rely on common sense and security checks after merging.