### PR TITLE
fix expected nullable type

### DIFF
--- a/tests/integration/dbapi/conftest.py
+++ b/tests/integration/dbapi/conftest.py
@@ -41,7 +41,7 @@ def all_types_query_description() -> List[Column]:
         Column("datetime", datetime, None, None, None, None, None),
         Column("bool", int, None, None, None, None, None),
         Column("array", ARRAY(int), None, None, None, None, None),
-        Column("nullable", str, None, None, None, None, None),
+        Column("nullable", int, None, None, None, None, None),
     ]
 
 


### PR DESCRIPTION
Fixed failing integration tests
For some reason, we were selecting `nullable(int)` and receiving `nullable(str)`. This seems to be fixed now
Test run:
https://github.com/firebolt-db/firebolt-python-sdk/runs/5377713096?check_suite_focus=true