### PR TITLE
fix: Compatibility with cryptography 2.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ dev =
     pytest-mock==3.6.1
     pytest-timeout==2.1.0
     pytest-xdist==2.5.0
+    types-cryptography==3.3.18
 
 [options.package_data]
 firebolt = py.typed

--- a/src/firebolt/common/token_storage.py
+++ b/src/firebolt/common/token_storage.py
@@ -9,6 +9,9 @@ from typing import Optional
 
 from appdirs import user_data_dir
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.backends.openssl.backend import (
+    backend as ossl_backend,
+)
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
@@ -114,6 +117,7 @@ class FernetEncrypter:
             salt=b64decode(salt),
             length=32,
             iterations=39000,
+            backend=ossl_backend,
         )
         self.fernet = Fernet(
             urlsafe_b64encode(

--- a/src/firebolt/common/token_storage.py
+++ b/src/firebolt/common/token_storage.py
@@ -9,11 +9,11 @@ from typing import Optional
 
 from appdirs import user_data_dir
 from cryptography.fernet import Fernet, InvalidToken
-from cryptography.hazmat.backends.openssl.backend import (
-    backend as ossl_backend,
+from cryptography.hazmat.backends import default_backend  # type: ignore
+from cryptography.hazmat.primitives import hashes  # type: ignore
+from cryptography.hazmat.primitives.kdf.pbkdf2 import (
+    PBKDF2HMAC,  # type: ignore
 )
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 APPNAME = "firebolt"
 
@@ -117,7 +117,7 @@ class FernetEncrypter:
             salt=b64decode(salt),
             length=32,
             iterations=39000,
-            backend=ossl_backend,
+            backend=default_backend(),
         )
         self.fernet = Fernet(
             urlsafe_b64encode(


### PR DESCRIPTION
According to cryptograpy 3.1 changelog
```
**backend** arguments to functions are no longer required and the default backend will automatically be selected if no backend is provided.
```
In order to be compatible with cryptography 2.8, required by Redash, we should provide default backend as an argument 