### PR TITLE
feat: Fir 12126 make engine parameter optional

### DIFF
--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -83,7 +83,6 @@ async def _get_database_default_engine_url(
     ) as client:
         try:
             account_id = await client.account_id
-            # Get database id by name
             response = await client.get(
                 url=ACCOUNT_ENGINE_URL_BY_DATABASE_NAME.format(account_id=account_id),
                 params={"database_name": database},

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -50,10 +50,9 @@ async def _resolve_engine_url(
             )
             response.raise_for_status()
             engine_id = response.json()["engine_id"]["engine_id"]
-
             response = await client.get(
                 url=ACCOUNT_ENGINE_URL.format(
-                    account_id=(await client.account_id), engine_id=engine_id
+                    account_id=account_id, engine_id=engine_id
                 ),
             )
             response.raise_for_status()

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -113,7 +113,7 @@ async def _get_database_default_engine_url(
                 raise FireboltDatabaseError(
                     f"Database {database} has no default engines"
                 )
-            engine_id = default_engines_bindings[0].binding_key.engine_id
+            engine_id = default_engines_bindings[0]["id"]["engine_id"]
 
             return await _get_engine_endpoint(client, engine_id)
         except (

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -150,7 +150,7 @@ def async_connect_factory(connection_class: Type) -> Callable:
             api_endpoint(optional): Firebolt API endpoint. Used for authentication.
 
         Note:
-            Either `engine_name` or `engine_url` should be provided, but not both.
+            Providing both `engine_name` and `engine_url` would result in an error.
 
         """
         # These parameters are optional in function signature

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -105,8 +105,11 @@ async def _get_database_default_engine_url(
                 },
             )
             response.raise_for_status()
+            print(response.json()["edges"])
             default_engines_bindings = [
-                b for b in response.json()["edges"] if b["engine_is_default"]
+                b["node"]
+                for b in response.json()["edges"]
+                if b["node"]["engine_is_default"]
             ]
 
             if len(default_engines_bindings) == 0:

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -105,7 +105,6 @@ async def _get_database_default_engine_url(
                 },
             )
             response.raise_for_status()
-            print(response.json()["edges"])
             default_engines_bindings = [
                 b["node"]
                 for b in response.json()["edges"]

--- a/src/firebolt/common/urls.py
+++ b/src/firebolt/common/urls.py
@@ -15,6 +15,7 @@ ACCOUNT_ENGINE_STOP_URL = ACCOUNT_ENGINE_URL + ":stop"
 ACCOUNT_ENGINES_URL = "/core/v1/accounts/{account_id}/engines"
 ACCOUNT_ENGINE_BY_NAME_URL = ACCOUNT_ENGINES_URL + ":getIdByName"
 ACCOUNT_ENGINE_REVISION_URL = ACCOUNT_ENGINE_URL + "/engineRevisions/{revision_id}"
+ACCOUNT_ENGINE_URL_BY_DATABASE_NAME = ACCOUNT_ENGINES_URL + ":getURLByDatabaseName"
 
 ACCOUNT_DATABASES_URL = "/core/v1/accounts/{account_id}/databases"
 ACCOUNT_DATABASE_URL = "/core/v1/accounts/{account_id}/databases/{database_id}"

--- a/tests/integration/dbapi/async/conftest.py
+++ b/tests/integration/dbapi/async/conftest.py
@@ -42,3 +42,22 @@ async def connection_engine_name(
         api_endpoint=api_endpoint,
     ) as connection:
         yield connection
+
+
+@fixture
+async def connection_no_engine(
+    database_name: str,
+    username: str,
+    password: str,
+    account_name: str,
+    api_endpoint: str,
+) -> Connection:
+
+    async with await connect(
+        database=database_name,
+        username=username,
+        password=password,
+        account_name=account_name,
+        api_endpoint=api_endpoint,
+    ) as connection:
+        yield connection

--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -33,6 +33,22 @@ async def test_connect_engine_name(
 
 
 @mark.asyncio
+async def test_connect_no_engine(
+    connection_no_engine: Connection,
+    all_types_query: str,
+    all_types_query_description: List[Column],
+    all_types_query_response: List[ColType],
+) -> None:
+    """Connecting with engine name is handled properly."""
+    await test_select(
+        connection_no_engine,
+        all_types_query,
+        all_types_query_description,
+        all_types_query_response,
+    )
+
+
+@mark.asyncio
 async def test_select(
     connection: Connection,
     all_types_query: str,

--- a/tests/integration/dbapi/sync/conftest.py
+++ b/tests/integration/dbapi/sync/conftest.py
@@ -43,3 +43,22 @@ def connection_engine_name(
     )
     yield connection
     connection.close()
+
+
+@fixture
+def connection_no_engine(
+    database_name: str,
+    username: str,
+    password: str,
+    account_name: str,
+    api_endpoint: str,
+) -> Connection:
+    connection = connect(
+        database=database_name,
+        username=username,
+        password=password,
+        account_name=account_name,
+        api_endpoint=api_endpoint,
+    )
+    yield connection
+    connection.close()

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -31,6 +31,21 @@ def test_connect_engine_name(
     )
 
 
+def test_connect_no_engine(
+    connection_no_engine: Connection,
+    all_types_query: str,
+    all_types_query_description: List[Column],
+    all_types_query_response: List[ColType],
+) -> None:
+    """Connecting with engine name is handled properly."""
+    test_select(
+        connection_no_engine,
+        all_types_query,
+        all_types_query_description,
+        all_types_query_response,
+    )
+
+
 def test_select(
     connection: Connection,
     all_types_query: str,

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -9,6 +9,7 @@ from firebolt.async_db._types import ColType
 from firebolt.common.exception import (
     ConfigurationError,
     ConnectionClosedError,
+    FireboltDatabaseError,
     FireboltEngineError,
 )
 from firebolt.common.settings import Settings
@@ -149,8 +150,6 @@ async def test_connect_engine_name(
     engine_id: str,
     get_engine_url: str,
     get_engine_callback: Callable,
-    get_providers_url: str,
-    get_providers_callback: Callable,
     python_query_data: List[List[ColType]],
     account_id: str,
 ):
@@ -204,6 +203,100 @@ async def test_connect_engine_name(
 
     async with await connect(
         engine_name=engine_name,
+        database=db_name,
+        username="u",
+        password="p",
+        account_name=settings.account_name,
+        api_endpoint=settings.server,
+    ) as connection:
+        assert await connection.cursor().execute("select*") == len(python_query_data)
+
+
+@mark.asyncio
+async def test_connect_default_engine(
+    settings: Settings,
+    db_name: str,
+    httpx_mock: HTTPXMock,
+    auth_callback: Callable,
+    auth_url: str,
+    query_callback: Callable,
+    query_url: str,
+    account_id_url: str,
+    account_id_callback: Callable,
+    engine_id: str,
+    get_engine_url: str,
+    get_engine_callback: Callable,
+    database_by_name_url: str,
+    database_by_name_callback: Callable,
+    database_id: str,
+    bindings_url: str,
+    python_query_data: List[List[ColType]],
+    account_id: str,
+):
+    httpx_mock.add_callback(auth_callback, url=auth_url)
+    httpx_mock.add_callback(query_callback, url=query_url)
+    httpx_mock.add_callback(account_id_callback, url=account_id_url)
+    httpx_mock.add_callback(database_by_name_callback, url=database_by_name_url)
+    bindings_url = f"{bindings_url}?filter.id_database_id_eq={database_id}"
+    httpx_mock.add_response(
+        url=bindings_url,
+        status_code=codes.OK,
+        json={"edges": []},
+    )
+
+    with raises(FireboltDatabaseError):
+        async with await connect(
+            database=db_name,
+            username="u",
+            password="p",
+            account_name=settings.account_name,
+            api_endpoint=settings.server,
+        ):
+            pass
+
+    httpx_mock.add_response(
+        url=bindings_url,
+        status_code=codes.OK,
+        json={
+            "edges": [
+                {
+                    "engine_is_default": False,
+                    "id": {"engine_id": engine_id},
+                }
+            ]
+        },
+    )
+
+    with raises(FireboltDatabaseError):
+        async with await connect(
+            database=db_name,
+            username="u",
+            password="p",
+            account_name=settings.account_name,
+            api_endpoint=settings.server,
+        ):
+            pass
+
+    non_default_engine_id = "non_default_engine_id"
+
+    httpx_mock.add_response(
+        url=bindings_url,
+        status_code=codes.OK,
+        json={
+            "edges": [
+                {
+                    "engine_is_default": False,
+                    "id": {"engine_id": non_default_engine_id},
+                },
+                {
+                    "engine_is_default": True,
+                    "id": {"engine_id": engine_id},
+                },
+            ]
+        },
+    )
+    httpx_mock.add_callback(get_engine_callback, url=get_engine_url)
+    async with await connect(
         database=db_name,
         username="u",
         password="p",

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -167,15 +167,6 @@ async def test_connect_engine_name(
         ):
             pass
 
-    with raises(ConfigurationError):
-        async with await connect(
-            database="db",
-            username="username",
-            password="password",
-            account_name="account",
-        ):
-            pass
-
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(query_callback, url=query_url)
     httpx_mock.add_callback(account_id_callback, url=account_id_url)

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -260,8 +260,10 @@ async def test_connect_default_engine(
         json={
             "edges": [
                 {
-                    "engine_is_default": False,
-                    "id": {"engine_id": engine_id},
+                    "node": {
+                        "engine_is_default": False,
+                        "id": {"engine_id": engine_id},
+                    }
                 }
             ]
         },
@@ -285,12 +287,16 @@ async def test_connect_default_engine(
         json={
             "edges": [
                 {
-                    "engine_is_default": False,
-                    "id": {"engine_id": non_default_engine_id},
+                    "node": {
+                        "engine_is_default": False,
+                        "id": {"engine_id": non_default_engine_id},
+                    }
                 },
                 {
-                    "engine_is_default": True,
-                    "id": {"engine_id": engine_id},
+                    "node": {
+                        "engine_is_default": True,
+                        "id": {"engine_id": engine_id},
+                    }
                 },
             ]
         },

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,10 +21,10 @@ from firebolt.common.exception import (
 )
 from firebolt.common.settings import Settings
 from firebolt.common.urls import (
-    ACCOUNT_BINDINGS_URL,
     ACCOUNT_BY_NAME_URL,
     ACCOUNT_DATABASE_BY_NAME_URL,
     ACCOUNT_ENGINE_URL,
+    ACCOUNT_ENGINE_URL_BY_DATABASE_NAME,
     ACCOUNT_URL,
     AUTH_URL,
     DATABASES_URL,
@@ -278,30 +278,11 @@ def database_by_name_callback(account_id: str, database_id: str) -> str:
 
 
 @fixture
-def bindings_url(settings: Settings, account_id: str) -> str:
+def engine_by_db_url(settings: Settings, account_id: str) -> str:
     return (
-        f"https://{settings.server}{ACCOUNT_BINDINGS_URL.format(account_id=account_id)}"
+        f"https://{settings.server}"
+        f"{ACCOUNT_ENGINE_URL_BY_DATABASE_NAME.format(account_id=account_id)}"
     )
-
-
-@fixture
-def bindings_callback(account_id: str, database_id: str) -> str:
-    def do_mock(
-        request: httpx.Request = None,
-        **kwargs,
-    ) -> Response:
-        assert request.url == get_providers_url
-        return Response(
-            status_code=httpx.codes.OK,
-            json={
-                "database_id": {
-                    "database_id": database_id,
-                    "account_id": account_id,
-                }
-            },
-        )
-
-    return do_mock
 
 
 @fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,7 +21,9 @@ from firebolt.common.exception import (
 )
 from firebolt.common.settings import Settings
 from firebolt.common.urls import (
+    ACCOUNT_BINDINGS_URL,
     ACCOUNT_BY_NAME_URL,
+    ACCOUNT_DATABASE_BY_NAME_URL,
     ACCOUNT_ENGINE_URL,
     ACCOUNT_URL,
     AUTH_URL,
@@ -240,6 +242,66 @@ def get_engines_url(settings: Settings) -> str:
 @fixture
 def get_databases_url(settings: Settings) -> str:
     return f"https://{settings.server}{DATABASES_URL}"
+
+
+@fixture
+def database_id() -> str:
+    return "database_id"
+
+
+@fixture
+def database_by_name_url(settings: Settings, account_id: str, db_name: str) -> str:
+    return (
+        f"https://{settings.server}"
+        f"{ACCOUNT_DATABASE_BY_NAME_URL.format(account_id=account_id)}"
+        f"?database_name={db_name}"
+    )
+
+
+@fixture
+def database_by_name_callback(account_id: str, database_id: str) -> str:
+    def do_mock(
+        request: httpx.Request = None,
+        **kwargs,
+    ) -> Response:
+        return Response(
+            status_code=httpx.codes.OK,
+            json={
+                "database_id": {
+                    "database_id": database_id,
+                    "account_id": account_id,
+                }
+            },
+        )
+
+    return do_mock
+
+
+@fixture
+def bindings_url(settings: Settings, account_id: str) -> str:
+    return (
+        f"https://{settings.server}{ACCOUNT_BINDINGS_URL.format(account_id=account_id)}"
+    )
+
+
+@fixture
+def bindings_callback(account_id: str, database_id: str) -> str:
+    def do_mock(
+        request: httpx.Request = None,
+        **kwargs,
+    ) -> Response:
+        assert request.url == get_providers_url
+        return Response(
+            status_code=httpx.codes.OK,
+            json={
+                "database_id": {
+                    "database_id": database_id,
+                    "account_id": account_id,
+                }
+            },
+        )
+
+    return do_mock
 
 
 @fixture

--- a/tests/unit/db/test_connection.py
+++ b/tests/unit/db/test_connection.py
@@ -230,8 +230,10 @@ def test_connect_default_engine(
         json={
             "edges": [
                 {
-                    "engine_is_default": False,
-                    "id": {"engine_id": engine_id},
+                    "node": {
+                        "engine_is_default": False,
+                        "id": {"engine_id": engine_id},
+                    }
                 }
             ]
         },
@@ -255,12 +257,16 @@ def test_connect_default_engine(
         json={
             "edges": [
                 {
-                    "engine_is_default": False,
-                    "id": {"engine_id": non_default_engine_id},
+                    "node": {
+                        "engine_is_default": False,
+                        "id": {"engine_id": non_default_engine_id},
+                    }
                 },
                 {
-                    "engine_is_default": True,
-                    "id": {"engine_id": engine_id},
+                    "node": {
+                        "engine_is_default": True,
+                        "id": {"engine_id": engine_id},
+                    }
                 },
             ]
         },

--- a/tests/unit/db/test_connection.py
+++ b/tests/unit/db/test_connection.py
@@ -5,11 +5,7 @@ from pytest import raises, warns
 from pytest_httpx import HTTPXMock
 
 from firebolt.async_db._types import ColType
-from firebolt.common.exception import (
-    ConfigurationError,
-    ConnectionClosedError,
-    FireboltDatabaseError,
-)
+from firebolt.common.exception import ConfigurationError, ConnectionClosedError
 from firebolt.common.settings import Settings
 from firebolt.common.urls import ACCOUNT_ENGINE_BY_NAME_URL
 from firebolt.db import Connection, connect
@@ -199,79 +195,22 @@ def test_connect_default_engine(
     database_by_name_url: str,
     database_by_name_callback: Callable,
     database_id: str,
-    bindings_url: str,
+    engine_by_db_url: str,
     python_query_data: List[List[ColType]],
     account_id: str,
 ):
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(query_callback, url=query_url)
     httpx_mock.add_callback(account_id_callback, url=account_id_url)
-    httpx_mock.add_callback(database_by_name_callback, url=database_by_name_url)
-    bindings_url = f"{bindings_url}?filter.id_database_id_eq={database_id}"
-    httpx_mock.add_response(
-        url=bindings_url,
-        status_code=codes.OK,
-        json={"edges": []},
-    )
-
-    with raises(FireboltDatabaseError):
-        with connect(
-            database=db_name,
-            username="u",
-            password="p",
-            account_name=settings.account_name,
-            api_endpoint=settings.server,
-        ):
-            pass
+    engine_by_db_url = f"{engine_by_db_url}?database_name={db_name}"
 
     httpx_mock.add_response(
-        url=bindings_url,
+        url=engine_by_db_url,
         status_code=codes.OK,
         json={
-            "edges": [
-                {
-                    "node": {
-                        "engine_is_default": False,
-                        "id": {"engine_id": engine_id},
-                    }
-                }
-            ]
+            "engine_url": settings.server,
         },
     )
-
-    with raises(FireboltDatabaseError):
-        with connect(
-            database=db_name,
-            username="u",
-            password="p",
-            account_name=settings.account_name,
-            api_endpoint=settings.server,
-        ):
-            pass
-
-    non_default_engine_id = "non_default_engine_id"
-
-    httpx_mock.add_response(
-        url=bindings_url,
-        status_code=codes.OK,
-        json={
-            "edges": [
-                {
-                    "node": {
-                        "engine_is_default": False,
-                        "id": {"engine_id": non_default_engine_id},
-                    }
-                },
-                {
-                    "node": {
-                        "engine_is_default": True,
-                        "id": {"engine_id": engine_id},
-                    }
-                },
-            ]
-        },
-    )
-    httpx_mock.add_callback(get_engine_callback, url=get_engine_url)
     with connect(
         database=db_name,
         username="u",

--- a/tests/unit/db/test_connection.py
+++ b/tests/unit/db/test_connection.py
@@ -152,13 +152,6 @@ def test_connect_engine_name(
             password="password",
         )
 
-    with raises(ConfigurationError):
-        connect(
-            database="db",
-            username="username",
-            password="password",
-        )
-
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(query_callback, url=query_url)
     httpx_mock.add_callback(account_id_callback, url=account_id_url)


### PR DESCRIPTION
Allow users to skip engine parameter. Get default engine url in this case.
Added unit and integration tests