### PR TITLE
ci: Fir 12453 add security scans to nightly 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
   security-scan:
     needs: [unit-tests]
     uses: ./.github/workflows/security-scan.yml
-    with:
+    secrets:
       FOSSA_TOKEN: ${{ secrets.FOSSA_TOKEN }}
       SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
   tests:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,14 @@ on:
 jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml
+  unit-tests:
+    uses: ./.github/workflows/unit-tests.yml
+  security-scan:
+    needs: [unit-tests]
+    uses: ./.github/workflows/security-scan.yml
+    with:
+      FOSSA_TOKEN: ${{ secrets.FOSSA_TOKEN }}
+      SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
   tests:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tests/integration/resource_manager/test_engine.py
+++ b/tests/integration/resource_manager/test_engine.py
@@ -12,10 +12,14 @@ from firebolt.service.types import (
 )
 
 
+def make_engine_name(database_name: str, suffix: str) -> str:
+    return f"{database_name}_{suffix}_{int(time.time())}"
+
+
 @pytest.mark.skip(reason="manual test")
-def test_create_start_stop_engine():
+def test_create_start_stop_engine(database_name: str):
     rm = ResourceManager()
-    name = f"integration_test_{int(time.time())}"
+    name = make_engine_name(database_name, "create_start_stop_eng")
 
     engine = rm.engines.create(name=name)
     assert engine.name == name
@@ -40,9 +44,9 @@ def test_create_start_stop_engine():
 
 
 @pytest.mark.skip(reason="manual test")
-def test_copy_engine():
+def test_copy_engine(database_name):
     rm = ResourceManager()
-    name = f"integration_test_{int(time.time())}"
+    name = make_engine_name(database_name, "copy_engine")
 
     engine = rm.engines.create(name=name)
     assert engine.name == name
@@ -111,7 +115,7 @@ ENGINE_UPDATE_PARAMS = {
 def test_engine_update_single_parameter(rm_settings: Settings, database_name: str):
     rm = ResourceManager(rm_settings)
 
-    name = f"integration_test_{int(time.time())}"
+    name = make_engine_name(database_name, "engine_single_parameter")
     engine = rm.engines.create(name=name)
 
     engine.attach_to_database(database=rm.databases.get_by_name(database_name))
@@ -130,7 +134,7 @@ def test_engine_update_single_parameter(rm_settings: Settings, database_name: st
 def test_engine_update_multiple_parameters(rm_settings: Settings, database_name: str):
     rm = ResourceManager(rm_settings)
 
-    name = f"integration_test_{int(time.time())}"
+    name = make_engine_name(database_name, "engine_multi_parameter")
     engine = rm.engines.create(name=name)
 
     engine.attach_to_database(database=rm.databases.get_by_name(database_name))

--- a/tests/integration/resource_manager/test_engine.py
+++ b/tests/integration/resource_manager/test_engine.py
@@ -1,4 +1,3 @@
-import time
 from collections import namedtuple
 
 import pytest
@@ -13,13 +12,13 @@ from firebolt.service.types import (
 
 
 def make_engine_name(database_name: str, suffix: str) -> str:
-    return f"{database_name}_{suffix}_{int(time.time())}"
+    return f"{database_name}_{suffix}"
 
 
 @pytest.mark.skip(reason="manual test")
 def test_create_start_stop_engine(database_name: str):
     rm = ResourceManager()
-    name = make_engine_name(database_name, "create_start_stop_eng")
+    name = make_engine_name(database_name, "start_stop")
 
     engine = rm.engines.create(name=name)
     assert engine.name == name
@@ -46,7 +45,7 @@ def test_create_start_stop_engine(database_name: str):
 @pytest.mark.skip(reason="manual test")
 def test_copy_engine(database_name):
     rm = ResourceManager()
-    name = make_engine_name(database_name, "copy_engine")
+    name = make_engine_name(database_name, "copy")
 
     engine = rm.engines.create(name=name)
     assert engine.name == name
@@ -115,7 +114,7 @@ ENGINE_UPDATE_PARAMS = {
 def test_engine_update_single_parameter(rm_settings: Settings, database_name: str):
     rm = ResourceManager(rm_settings)
 
-    name = make_engine_name(database_name, "engine_single_parameter")
+    name = make_engine_name(database_name, "single_param")
     engine = rm.engines.create(name=name)
 
     engine.attach_to_database(database=rm.databases.get_by_name(database_name))
@@ -134,7 +133,7 @@ def test_engine_update_single_parameter(rm_settings: Settings, database_name: st
 def test_engine_update_multiple_parameters(rm_settings: Settings, database_name: str):
     rm = ResourceManager(rm_settings)
 
-    name = make_engine_name(database_name, "engine_multi_parameter")
+    name = make_engine_name(database_name, "multi_param")
     engine = rm.engines.create(name=name)
 
     engine.attach_to_database(database=rm.databases.get_by_name(database_name))


### PR DESCRIPTION
Fixed nightly resource manager tests. The issue was that engine name wasn't unique when it was being created.
Used database_name to make it unique
Added security scans to nightly job