### PR TITLE
docs(FIR-12444): Add CI badges to readme

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,4 +1,4 @@
-name: Python code checks
+name: Code quality checks
 
 on:
   workflow_call:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: Run integration tests
+name: Integration tests
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,9 @@ jobs:
     uses: ./.github/workflows/code-check.yml
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
+    secrets:
+      GIST_PAT: ${{ secrets.GIST_PAT }}
+      
   security-scan:
     needs: [unit-tests]
     uses: ./.github/workflows/security-scan.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,7 +45,10 @@ jobs:
       run: |
         fraction=$(sed -n 2p coverage.xml | sed 's/.*line-rate=\"\([0-9.]*\)\".*$/\1/')
         percentage=$(echo "scale=1; $fraction * 100" | bc -l)
-        echo "::set-output name=covered::${percentage%.*}"
+        percentage_whole=$(echo "${percentage%.*}")
+        colour=$(if [ $percentage_whole -ge 80 ]; then echo "green"; else echo "orange"; fi)
+        echo "::set-output name=colour::$colour"
+        echo "::set-output name=covered::$percentage_whole"
     
     - name: Create Coverage Badge
       uses: schneegans/dynamic-badges-action@v1.2.0
@@ -55,4 +58,4 @@ jobs:
         filename: firebolt-sdk-coverage.json
         label: Coverage
         message: ${{steps.coverage.outputs.covered}}%
-        color: orange
+        color: ${{steps.coverage.outputs.colour}}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         fraction=$(sed -n 2p coverage.xml | sed 's/.*line-rate=\"\([0-9.]*\)\".*$/\1/')
         percentage=$(echo "scale=1; $fraction * 100" | bc -l)
-        echo "::set-output name=covered::${perc%.*}\n"
+        echo "::set-output name=covered::${percentage%.*}"
     
     - name: Create Coverage Badge
       uses: schneegans/dynamic-badges-action@v1.2.0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,3 +36,20 @@ jobs:
       with:
         name: pytest-coverage-report
         path: coverage.xml
+        
+    - name: Extract coverage percent
+      id: coverage
+      run: |
+        fraction=$(sed -n 2p coverage.xml | sed 's/.*line-rate=\"\([0-9.]*\)\".*$/\1/')
+        percentage=$(echo "scale=1; $fraction * 100" | bc -l)
+        echo "::set-output name=covered::${perc%.*}\n"
+    
+    - name: Create Coverage Badge
+      uses: schneegans/dynamic-badges-action@v1.2.0
+      with:
+        auth: ${{ secrets.GIST_PAT }}
+        gistID: 65d5a42849fd78f4c6e62fad18490d20
+        filename: firebolt-sdk-coverage.json
+        label: Coverage
+        message: ${{steps.coverage.outputs.covered}}%
+        color: orange

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Extract coverage percent
       id: coverage
       if: github.event_name == 'push'
+      continue-on-error: true
       run: |
         fraction=$(sed -n 2p coverage.xml | sed 's/.*line-rate=\"\([0-9.]*\)\".*$/\1/')
         percentage=$(echo "scale=1; $fraction * 100" | bc -l)
@@ -54,6 +55,7 @@ jobs:
     - name: Create Coverage Badge
       uses: schneegans/dynamic-badges-action@v1.2.0
       if: github.event_name == 'push'
+      continue-on-error: true
       with:
         auth: ${{ secrets.GIST_PAT }}
         gistID: 65d5a42849fd78f4c6e62fad18490d20

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,9 @@ name: Unit tests
 
 on:
   workflow_call:
+    secrets:
+      GIST_PAT:
+        required: true
   push:
     branches: [ main ]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,6 +42,7 @@ jobs:
         
     - name: Extract coverage percent
       id: coverage
+      if: github.event_name == 'push'
       run: |
         fraction=$(sed -n 2p coverage.xml | sed 's/.*line-rate=\"\([0-9.]*\)\".*$/\1/')
         percentage=$(echo "scale=1; $fraction * 100" | bc -l)
@@ -52,6 +53,7 @@ jobs:
     
     - name: Create Coverage Badge
       uses: schneegans/dynamic-badges-action@v1.2.0
+      if: github.event_name == 'push'
       with:
         auth: ${{ secrets.GIST_PAT }}
         gistID: 65d5a42849fd78f4c6e62fad18490d20

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # firebolt-sdk
+[![Nightly code check](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/nightly.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/nightly.yml)
+[![Unit tests](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/unit-tests.yml)
+[![Code checks](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml)
+[![Firebolt Security Scan](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/security-scan.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/security-scan.yml)
+[![Integration tests](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/integration-tests.yml)
+
+[![GitHub license](https://img.shields.io/github/license/firebolt-db/firebolt-python-sdk)](https://github.com/firebolt-db/firebolt-python-sdk/blob/main/LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues/firebolt-db/firebolt-python-sdk)](https://github.com/firebolt-db/firebolt-python-sdk/issues)
+
 ### Installation
 
 * Requires Python `>=3.7`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # firebolt-sdk
 [![Nightly code check](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/nightly.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/nightly.yml)
 [![Unit tests](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/unit-tests.yml)
-[![Code checks](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml)
+[![Code quality checks](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml)
 [![Firebolt Security Scan](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/security-scan.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/security-scan.yml)
 [![Integration tests](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/integration-tests.yml)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 [![Code quality checks](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/code-check.yml)
 [![Firebolt Security Scan](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/security-scan.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/security-scan.yml)
 [![Integration tests](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/firebolt-db/firebolt-python-sdk/actions/workflows/integration-tests.yml)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ptiurin/65d5a42849fd78f4c6e62fad18490d20/raw/firebolt-sdk-coverage.json)
 
-[![GitHub license](https://img.shields.io/github/license/firebolt-db/firebolt-python-sdk)](https://github.com/firebolt-db/firebolt-python-sdk/blob/main/LICENSE)
-[![GitHub issues](https://img.shields.io/github/issues/firebolt-db/firebolt-python-sdk)](https://github.com/firebolt-db/firebolt-python-sdk/issues)
 
 ### Installation
 


### PR DESCRIPTION
Adding CI badges to indicate code quality standards to repo contributors. 

Coverage is extracted from the report, uploaded to a gist, which is then referenced in the Readme. This ensures there's no need to commit an update to the readme to see the coverage changing.