### PR TITLE
ci: Add unit-test secret to nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,8 @@ jobs:
     uses: ./.github/workflows/code-check.yml
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
+    secrets:
+      GIST_PAT: ${{ secrets.GIST_PAT }}
   security-scan:
     needs: [unit-tests]
     uses: ./.github/workflows/security-scan.yml


### PR DESCRIPTION
Since the addition of readme badges nightly has been broken. Unit-test workflow needs a GIST_PAT secret. Adding it to resolve the error.