### PR TITLE
feat: Fir 12879 allow skipping token caching

### DIFF
--- a/src/firebolt/common/settings.py
+++ b/src/firebolt/common/settings.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     account_name: str = Field(None, env="FIREBOLT_ACCOUNT")
     server: str = Field(..., env="FIREBOLT_SERVER")
     default_region: str = Field(..., env="FIREBOLT_DEFAULT_REGION")
+    use_token_cache: bool = Field(True)
 
     class Config:
         """Internal pydantic config."""

--- a/src/firebolt/model/engine.py
+++ b/src/firebolt/model/engine.py
@@ -184,13 +184,21 @@ class Engine(FireboltBaseModel):
 
     @check_attached_to_database
     def get_connection(self) -> Connection:
-        """Get a connection to the attached database, for running queries."""
+        """Get a connection to the attached database, for running queries.
+
+        Returns:
+            Connection: engine connection instance
+
+        """
         return connect(
-            engine_url=self.endpoint,
             database=self.database.name,  # type: ignore # already checked by decorator
             username=self._service.settings.user,
             password=self._service.settings.password.get_secret_value(),
+            access_token=self._service.settings.access_token,
+            engine_url=self.endpoint,
+            account_name=self._service.settings.account_name,
             api_endpoint=self._service.settings.server,
+            use_token_cache=self._service.settings.use_token_cache,
         )
 
     @check_attached_to_database
@@ -226,7 +234,7 @@ class Engine(FireboltBaseModel):
         ):
             logger.info(
                 f"Engine (engine_id={self.engine_id}, name={self.name}) "
-                f"is already running."
+                "is already running."
             )
             return engine
 
@@ -238,7 +246,7 @@ class Engine(FireboltBaseModel):
         ):
             logger.info(
                 f"Engine (engine_id={engine.engine_id}, name={engine.name}) "
-                f"is in currently stopping, waiting for it to stop first."
+                "is in currently stopping, waiting for it to stop first."
             )
             while (
                 engine.current_status_summary
@@ -247,9 +255,11 @@ class Engine(FireboltBaseModel):
                 wait(
                     seconds=5,
                     timeout_time=timeout_time,
-                    error_message=f"Engine "
-                    f"(engine_id={engine.engine_id}, name={engine.name}) "
-                    f"did not stop within {wait_timeout_seconds} seconds.",
+                    error_message=(
+                        "Engine "
+                        f"(engine_id={engine.engine_id}, name={engine.name}) "
+                        f"did not stop within {wait_timeout_seconds} seconds."
+                    ),
                     verbose=True,
                 )
                 engine = engine.get_latest()
@@ -271,14 +281,16 @@ class Engine(FireboltBaseModel):
             wait(
                 seconds=5,
                 timeout_time=timeout_time,
-                error_message=f"Could not start engine within {wait_timeout_seconds} seconds.",  # noqa: E501
+                error_message=(  # noqa: E501
+                    f"Could not start engine within {wait_timeout_seconds} seconds."
+                ),
                 verbose=verbose,
             )
             previous_status_summary = engine.current_status_summary
             engine = engine.get_latest()
             if engine.current_status_summary != previous_status_summary:
                 logger.info(
-                    f"Engine status_summary="
+                    "Engine status_summary="
                     f"{getattr(engine.current_status_summary, 'name')}"
                 )
 
@@ -301,7 +313,9 @@ class Engine(FireboltBaseModel):
             wait(
                 seconds=5,
                 timeout_time=timeout_time,
-                error_message=f"Could not stop engine within {wait_timeout_seconds} seconds.",  # noqa: E501
+                error_message=(  # noqa: E501
+                    f"Could not stop engine within {wait_timeout_seconds} seconds."
+                ),
                 verbose=False,
             )
 
@@ -431,7 +445,9 @@ class Engine(FireboltBaseModel):
             wait(
                 seconds=5,
                 timeout_time=timeout_time,
-                error_message=f"Could not restart engine within {wait_timeout_seconds} seconds.",  # noqa: E501
+                error_message=(  # noqa: E501
+                    f"Could not restart engine within {wait_timeout_seconds} seconds."
+                ),
                 verbose=False,
             )
 

--- a/src/firebolt/service/manager.py
+++ b/src/firebolt/service/manager.py
@@ -39,7 +39,12 @@ class ResourceManager:
         if self.settings.access_token:
             auth = Auth.from_token(self.settings.access_token)
         else:
-            auth = (self.settings.user, self.settings.password.get_secret_value())
+            auth = Auth(
+                self.settings.user,
+                self.settings.password.get_secret_value(),
+                self.settings.server,
+                self.settings.use_token_cache,
+            )
 
         self.client = Client(
             auth=auth,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,10 +37,18 @@ from tests.unit.db_conftest import *  # noqa
 from tests.unit.util import list_to_paginated_response
 
 
+# Register nofakefs mark
+def pytest_configure(config):
+    config.addinivalue_line("markers", "nofakefs: don't use fakefs fixture")
+
+
 @fixture(autouse=True)
-def global_fake_fs() -> None:
-    with Patcher():
+def global_fake_fs(request) -> None:
+    if "nofakefs" in request.keywords:
         yield
+    else:
+        with Patcher():
+            yield
 
 
 @fixture

--- a/tests/unit/service/test_resource_manager.py
+++ b/tests/unit/service/test_resource_manager.py
@@ -1,8 +1,11 @@
 from typing import Callable
 
+from pyfakefs.fake_filesystem_unittest import Patcher
+from pytest import mark
 from pytest_httpx import HTTPXMock
 
 from firebolt.common.settings import Settings
+from firebolt.common.token_storage import TokenSecureStorage
 from firebolt.service.manager import ResourceManager
 
 
@@ -16,8 +19,6 @@ def test_rm_credentials(
     account_id_callback: Callable,
     provider_callback: Callable,
     provider_url: str,
-    region_callback: Callable,
-    region_url: str,
     access_token: str,
 ) -> None:
     """Creadentials, that are passed to rm are processed properly."""
@@ -39,3 +40,56 @@ def test_rm_credentials(
 
     rm = ResourceManager(token_settings)
     rm.client.get(url)
+
+
+@mark.nofakefs
+def test_rm_token_cache(
+    httpx_mock: HTTPXMock,
+    check_token_callback: Callable,
+    check_credentials_callback: Callable,
+    settings: Settings,
+    auth_url: str,
+    account_id_url: str,
+    account_id_callback: Callable,
+    provider_callback: Callable,
+    provider_url: str,
+    access_token: str,
+) -> None:
+    """Creadentials, that are passed to rm are processed properly."""
+    url = "https://url"
+
+    httpx_mock.add_callback(check_credentials_callback, url=auth_url)
+    httpx_mock.add_callback(check_token_callback, url=url)
+    httpx_mock.add_callback(provider_callback, url=provider_url)
+    httpx_mock.add_callback(account_id_callback, url=account_id_url)
+
+    with Patcher():
+        local_settings = Settings(
+            user=settings.user,
+            password=settings.password.get_secret_value(),
+            server=settings.server,
+            default_region=settings.default_region,
+            use_token_cache=True,
+        )
+        rm = ResourceManager(local_settings)
+        rm.client.get(url)
+
+        ts = TokenSecureStorage(settings.user, settings.password.get_secret_value())
+        assert ts.get_cached_token() == access_token, "Invalid token value cached"
+
+    # Do the same, but with use_token_cache=False
+    with Patcher():
+        local_settings = Settings(
+            user=settings.user,
+            password=settings.password.get_secret_value(),
+            server=settings.server,
+            default_region=settings.default_region,
+            use_token_cache=False,
+        )
+        rm = ResourceManager(local_settings)
+        rm.client.get(url)
+
+        ts = TokenSecureStorage(settings.user, settings.password.get_secret_value())
+        assert (
+            ts.get_cached_token() is None
+        ), "Token is cached even though caching is disabled"


### PR DESCRIPTION
Added ability to disable token caching.
It now could be disabled with`use_token_cache=False`, provided as a `connect` function argument or as a `Settings` field.
Added unit tests
