### PR TITLE
fix: Sync execution of tracker tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,15 +24,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
+      - name: Setup database and engine
+        id: setup
+        uses: firebolt-db/integration-testing-setup@master
+        with:
+          firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
+          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
+          api-endpoint: "api.dev.firebolt.io"
+          region: "us-east-1"
+
       - name: Run integration tests
         env:
           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
-          DATABASE_NAME: "integration_testing__1656065595"
-          ENGINE_NAME: "integration_testing__1656065595"
-          ENGINE_URL: "integration-testing-1656065595.firebolt.us-east-1.dev.firebolt.io"
-          STOPPED_ENGINE_NAME: "integration_testing__1656065595_stopped"
-          STOPPED_ENGINE_URL: "integration-testing-1656065595-stopped.firebolt.us-east-1.dev.firebolt.io"
+          DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
+          ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
+          ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
+          STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
+          STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
           API_ENDPOINT: "api.dev.firebolt.io"
           ACCOUNT_NAME: "firebolt"
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,24 +24,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
-      - name: Setup database and engine
-        id: setup
-        uses: firebolt-db/integration-testing-setup@master
-        with:
-          firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
-          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
-          api-endpoint: "api.dev.firebolt.io"
-          region: "us-east-1"
-
       - name: Run integration tests
         env:
           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
-          DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
-          ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
-          STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
-          STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
+          DATABASE_NAME: "integration_testing__1656065595"
+          ENGINE_NAME: "integration_testing__1656065595"
+          ENGINE_URL: "integration-testing-1656065595.firebolt.us-east-1.dev.firebolt.io"
+          STOPPED_ENGINE_NAME: "integration_testing__1656065595_stopped"
+          STOPPED_ENGINE_URL: "integration-testing-1656065595-stopped.firebolt.us-east-1.dev.firebolt.io"
           API_ENDPOINT: "api.dev.firebolt.io"
           ACCOUNT_NAME: "firebolt"
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,5 +45,5 @@ jobs:
           API_ENDPOINT: "api.dev.firebolt.io"
           ACCOUNT_NAME: "firebolt"
         run: |
-          pytest -n 6 --timeout_method "signal" -o log_cli=true -o log_cli_level=INFO tests/integration
+          pytest -n 6 --dist loadgroup --timeout_method "signal" -o log_cli=true -o log_cli_level=INFO tests/integration
         

--- a/tests/integration/utils/test_usage_tracker.py
+++ b/tests/integration/utils/test_usage_tracker.py
@@ -18,7 +18,7 @@ MOCK_MODULES = [
 
 
 @mark.xdist_group(name="usage_tracker")
-@fixture(scope="module", autouse=True)
+@fixture(scope="module")
 def create_cli_mock():
     # Cleanup before starting
     rmtree(TEST_FOLDER, ignore_errors=True)
@@ -69,7 +69,7 @@ def create_test_file(code: str, function_name: str, file_path: str):
         ("open", "dbt/adapters/firebolt/connections.py", "DBT/1.0.3"),
     ],
 )
-def test_usage_detection(function, path, expected, test_model):
+def test_usage_detection(function, path, expected, test_model, create_cli_mock):
     test_path = TEST_FOLDER + path
     create_test_file(test_model, function, test_path)
     result = run(

--- a/tests/integration/utils/test_usage_tracker.py
+++ b/tests/integration/utils/test_usage_tracker.py
@@ -17,6 +17,7 @@ MOCK_MODULES = [
 ]
 
 
+@mark.xdist_group(name="usage_tracker")
 @fixture(scope="module", autouse=True)
 def create_cli_mock():
     # Cleanup before starting
@@ -32,6 +33,8 @@ def create_cli_mock():
     rmtree(TEST_FOLDER)
 
 
+
+@mark.xdist_group(name="usage_tracker")
 @fixture(scope="module")
 def test_model():
     with open(TEST_SCRIPT_MODEL) as f:
@@ -45,6 +48,7 @@ def create_test_file(code: str, function_name: str, file_path: str):
         f.write(code)
 
 
+@mark.xdist_group(name="usage_tracker")
 @mark.parametrize(
     "function,path,expected",
     [

--- a/tests/integration/utils/test_usage_tracker.py
+++ b/tests/integration/utils/test_usage_tracker.py
@@ -33,7 +33,6 @@ def create_cli_mock():
     rmtree(TEST_FOLDER)
 
 
-
 @mark.xdist_group(name="usage_tracker")
 @fixture(scope="module")
 def test_model():


### PR DESCRIPTION
Making sure all tracker tests execute in the same process, if run in parallel.