### PR TITLE
build: Pin dev pytest-asyncio version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ dev =
     pre-commit==2.15.0
     pyfakefs>=4.5.3
     pytest==6.2.5
-    pytest-asyncio
+    pytest-asyncio<0.19.0
     pytest-cov==3.0.0
     pytest-httpx==0.21.0
     pytest-mock==3.6.1


### PR DESCRIPTION
New release of pytest-asyncio is breaking our unit tests on python `3.*.12` and `3.*.13`. Pinning it for now.