### PR TITLE
fix: Set asyncio_mode to deal with asyncio deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,3 +85,6 @@ ignore =
 ban-relative-imports = True
 docstring-convention = google
 inline-quotes = "
+
+[tool:pytest]
+asyncio_mode = auto

--- a/tests/integration/dbapi/async/test_auth_async.py
+++ b/tests/integration/dbapi/async/test_auth_async.py
@@ -7,7 +7,6 @@ from firebolt.utils.exception import AuthenticationError
 
 
 @mark.skip(reason="flaky, token not updated each time")
-@mark.asyncio
 async def test_refresh_token(connection: Connection) -> None:
     """Auth refreshes token on expiration/invalidation"""
     with connection.cursor() as c:
@@ -29,7 +28,6 @@ async def test_refresh_token(connection: Connection) -> None:
         assert c._client.auth.token != old, "Auth didn't update token on expiration."
 
 
-@mark.asyncio
 async def test_credentials_invalidation(connection: Connection) -> None:
     """Auth raises authentication error on credentials invalidation"""
     with connection.cursor() as c:

--- a/tests/integration/dbapi/async/test_errors_async.py
+++ b/tests/integration/dbapi/async/test_errors_async.py
@@ -1,5 +1,5 @@
 from httpx import ConnectError
-from pytest import mark, raises
+from pytest import raises
 
 from firebolt.async_db import Connection, connect
 from firebolt.utils.exception import (
@@ -12,7 +12,6 @@ from firebolt.utils.exception import (
 )
 
 
-@mark.asyncio
 async def test_invalid_credentials(
     engine_url: str, database_name: str, username: str, password: str, api_endpoint: str
 ) -> None:
@@ -32,7 +31,6 @@ async def test_invalid_credentials(
         ), "Invalid authentication error message."
 
 
-@mark.asyncio
 async def test_invalid_account(
     database_name: str,
     engine_name: str,
@@ -58,7 +56,6 @@ async def test_invalid_account(
         ), "Invalid account error message."
 
 
-@mark.asyncio
 async def test_engine_url_not_exists(
     engine_url: str,
     database_name: str,
@@ -80,7 +77,6 @@ async def test_engine_url_not_exists(
             await connection.cursor().execute("show tables")
 
 
-@mark.asyncio
 async def test_engine_name_not_exists(
     engine_name: str,
     database_name: str,
@@ -102,7 +98,6 @@ async def test_engine_name_not_exists(
             await connection.cursor().execute("show tables")
 
 
-@mark.asyncio
 async def test_engine_stopped(
     stopped_engine_url: str,
     database_name: str,
@@ -124,7 +119,6 @@ async def test_engine_stopped(
             await connection.cursor().execute("show tables")
 
 
-@mark.asyncio
 async def test_database_not_exists(
     engine_url: str, database_name: str, username: str, password: str, api_endpoint: str
 ) -> None:
@@ -145,7 +139,6 @@ async def test_database_not_exists(
         ), "Invalid database name error message."
 
 
-@mark.asyncio
 async def test_sql_error(connection: Connection) -> None:
     """Connection properly reacts to SQL execution error."""
     with connection.cursor() as c:

--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -16,7 +16,6 @@ def assert_deep_eq(got: Any, expected: Any, msg: str) -> bool:
     ), f"{msg}: {got}(got) != {expected}(expected)"
 
 
-@mark.asyncio
 async def test_connect_engine_name(
     connection_engine_name: Connection,
     all_types_query: str,
@@ -32,7 +31,6 @@ async def test_connect_engine_name(
     )
 
 
-@mark.asyncio
 async def test_connect_no_engine(
     connection_no_engine: Connection,
     all_types_query: str,
@@ -48,7 +46,6 @@ async def test_connect_no_engine(
     )
 
 
-@mark.asyncio
 async def test_select(
     connection: Connection,
     all_types_query: str,
@@ -83,7 +80,6 @@ async def test_select(
         )
 
 
-@mark.asyncio
 @mark.timeout(timeout=400)
 async def test_long_query(
     connection: Connection,
@@ -100,7 +96,6 @@ async def test_long_query(
         assert len(data) == 360, "Invalid data size returned by fetchall"
 
 
-@mark.asyncio
 async def test_drop_create(
     connection: Connection, create_drop_description: List[Column]
 ) -> None:
@@ -168,7 +163,6 @@ async def test_drop_create(
         await test_query(c, "DROP TABLE IF EXISTS test_drop_create_async_dim")
 
 
-@mark.asyncio
 async def test_insert(connection: Connection) -> None:
     """Insert and delete queries are handled properly."""
 
@@ -222,7 +216,6 @@ async def test_insert(connection: Connection) -> None:
         )
 
 
-@mark.asyncio
 async def test_parameterized_query(connection: Connection) -> None:
     """Query parameters are handled properly."""
 
@@ -284,7 +277,6 @@ async def test_parameterized_query(connection: Connection) -> None:
         )
 
 
-@mark.asyncio
 async def test_multi_statement_query(connection: Connection) -> None:
     """Query parameters are handled properly"""
 
@@ -345,7 +337,6 @@ async def test_multi_statement_query(connection: Connection) -> None:
         assert await c.nextset() is None
 
 
-@mark.asyncio
 async def test_set_invalid_parameter(connection: Connection):
     with connection.cursor() as c:
         assert len(c._set_parameters) == 0

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -21,7 +21,6 @@ from firebolt.utils.token_storage import TokenSecureStorage
 from firebolt.utils.urls import ACCOUNT_ENGINE_BY_NAME_URL
 
 
-@mark.asyncio
 async def test_closed_connection(connection: Connection) -> None:
     """Connection methods are unavailable for closed connection."""
     await connection.aclose()
@@ -36,7 +35,6 @@ async def test_closed_connection(connection: Connection) -> None:
     await connection.aclose()
 
 
-@mark.asyncio
 async def test_cursors_closed_on_close(connection: Connection) -> None:
     """Connection closes all its cursors on close."""
     c1, c2 = connection.cursor(), connection.cursor()
@@ -52,7 +50,6 @@ async def test_cursors_closed_on_close(connection: Connection) -> None:
     await connection.aclose()
 
 
-@mark.asyncio
 async def test_cursor_initialized(
     settings: Settings,
     db_name: str,
@@ -93,14 +90,12 @@ async def test_cursor_initialized(
             ), "Cursor wasn't removed from connection after close."
 
 
-@mark.asyncio
 async def test_connect_empty_parameters():
     with raises(ConfigurationError):
         async with await connect(engine_url="engine_url"):
             pass
 
 
-@mark.asyncio
 async def test_connect_access_token(
     settings: Settings,
     db_name: str,
@@ -139,7 +134,6 @@ async def test_connect_access_token(
             pass
 
 
-@mark.asyncio
 async def test_connect_engine_name(
     settings: Settings,
     db_name: str,
@@ -215,7 +209,6 @@ async def test_connect_engine_name(
         assert await connection.cursor().execute("select*") == len(python_query_data)
 
 
-@mark.asyncio
 async def test_connect_default_engine(
     settings: Settings,
     db_name: str,
@@ -258,7 +251,6 @@ async def test_connect_default_engine(
         assert await connection.cursor().execute("select*") == len(python_query_data)
 
 
-@mark.asyncio
 async def test_connection_commit(connection: Connection):
     # nothing happens
     connection.commit()
@@ -268,7 +260,6 @@ async def test_connection_commit(connection: Connection):
         connection.commit()
 
 
-@mark.asyncio
 @mark.nofakefs
 async def test_connection_token_caching(
     settings: Settings,
@@ -324,7 +315,6 @@ async def test_connection_token_caching(
         ), "Token is cached even though caching is disabled"
 
 
-@mark.asyncio
 async def test_connect_with_auth(
     httpx_mock: HTTPXMock,
     settings: Settings,
@@ -356,7 +346,6 @@ async def test_connect_with_auth(
             await connection.cursor().execute("select*")
 
 
-@mark.asyncio
 async def test_connect_account_name(
     httpx_mock: HTTPXMock,
     auth: Auth,
@@ -390,7 +379,6 @@ async def test_connect_account_name(
         pass
 
 
-@mark.asyncio
 async def test_connect_with_user_agent(
     httpx_mock: HTTPXMock,
     settings: Settings,
@@ -422,7 +410,6 @@ async def test_connect_with_user_agent(
         ut.assert_called_once_with([("DriverA", "1.1")], [("MyConnector", "1.0")])
 
 
-@mark.asyncio
 async def test_connect_no_user_agent(
     httpx_mock: HTTPXMock,
     settings: Settings,

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -2,7 +2,7 @@ from typing import Callable, Dict, List
 from unittest.mock import patch
 
 from httpx import HTTPStatusError, StreamError, codes
-from pytest import mark, raises
+from pytest import raises
 from pytest_httpx import HTTPXMock
 
 from firebolt.async_db import Cursor
@@ -20,7 +20,6 @@ from firebolt.utils.exception import (
 from tests.unit.db_conftest import encode_param
 
 
-@mark.asyncio
 async def test_cursor_state(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -55,7 +54,6 @@ async def test_cursor_state(
     assert cursor._state == CursorState.CLOSED
 
 
-@mark.asyncio
 async def test_closed_cursor(cursor: Cursor):
     """Most cursor methods are unavailable for closed cursor."""
     fields = ("description", "rowcount", "statistics")
@@ -95,7 +93,6 @@ async def test_closed_cursor(cursor: Cursor):
     cursor.close()
 
 
-@mark.asyncio
 async def test_cursor_no_query(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -144,7 +141,6 @@ async def test_cursor_no_query(
         pass
 
 
-@mark.asyncio
 async def test_cursor_execute(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -204,7 +200,6 @@ async def test_cursor_execute(
         ), f"Invalid description for insert using {message}."
 
 
-@mark.asyncio
 async def test_cursor_server_side_async_execute(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -247,7 +242,6 @@ async def test_cursor_server_side_async_execute(
         ), f"Invalid description for insert using {message}."
 
 
-@mark.asyncio
 async def test_cursor_execute_error(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -340,7 +334,6 @@ async def test_cursor_execute_error(
         httpx_mock.reset(True)
 
 
-@mark.asyncio
 async def test_cursor_async_execute_error(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -427,7 +420,6 @@ async def test_cursor_async_execute_error(
         httpx_mock.reset(True)
 
 
-@mark.asyncio
 async def test_cursor_fetchone(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -460,7 +452,6 @@ async def test_cursor_fetchone(
         await cursor.fetchone()
 
 
-@mark.asyncio
 async def test_cursor_fetchmany(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -522,7 +513,6 @@ async def test_cursor_fetchmany(
         await cursor.fetchmany()
 
 
-@mark.asyncio
 async def test_cursor_fetchall(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -557,7 +547,6 @@ async def test_cursor_fetchall(
         await cursor.fetchall()
 
 
-@mark.asyncio
 async def test_cursor_multi_statement(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -620,7 +609,6 @@ async def test_cursor_multi_statement(
     assert await cursor.nextset() is None
 
 
-@mark.asyncio
 async def test_cursor_set_statements(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -690,7 +678,6 @@ async def test_cursor_set_statements(
     assert len(cursor._set_parameters) == 0
 
 
-@mark.asyncio
 async def test_cursor_set_parameters_sent(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,
@@ -716,7 +703,6 @@ async def test_cursor_set_parameters_sent(
     await cursor.execute("select 1")
 
 
-@mark.asyncio
 async def test_cursor_skip_parse(
     httpx_mock: HTTPXMock,
     auth_callback: Callable,

--- a/tests/unit/client/auth/test_auth_async.py
+++ b/tests/unit/client/auth/test_auth_async.py
@@ -11,7 +11,6 @@ from firebolt.utils.token_storage import TokenSecureStorage
 from tests.unit.util import async_execute_generator_requests
 
 
-@mark.asyncio
 async def test_auth_refresh_on_expiration(
     httpx_mock: HTTPXMock, test_token: str, test_token2: str
 ) -> None:
@@ -41,7 +40,6 @@ async def test_auth_refresh_on_expiration(
     assert auth.token == test_token2, "expired access token was not updated"
 
 
-@mark.asyncio
 async def test_auth_uses_same_token_if_valid(
     httpx_mock: HTTPXMock, test_token: str, test_token2: str
 ) -> None:
@@ -74,7 +72,6 @@ async def test_auth_uses_same_token_if_valid(
     assert auth.token == test_token, "shoud not update token until it expires"
 
 
-@mark.asyncio
 async def test_auth_adds_header(test_token: str) -> None:
     """Auth adds required authentication headers to httpx.Request."""
     auth = Auth(use_token_cache=False)
@@ -89,7 +86,6 @@ async def test_auth_adds_header(test_token: str) -> None:
     ), "missing authorization header"
 
 
-@mark.asyncio
 @mark.nofakefs
 async def test_auth_token_storage(
     httpx_mock: HTTPXMock,

--- a/tests/unit/client/test_client_async.py
+++ b/tests/unit/client/test_client_async.py
@@ -2,7 +2,7 @@ from re import Pattern
 from typing import Callable
 
 from httpx import codes
-from pytest import mark, raises
+from pytest import raises
 from pytest_httpx import HTTPXMock
 
 from firebolt.client import DEFAULT_API_URL, AsyncClient
@@ -12,7 +12,6 @@ from firebolt.utils.urls import AUTH_URL
 from firebolt.utils.util import fix_url_schema
 
 
-@mark.asyncio
 async def test_client_retry(
     httpx_mock: HTTPXMock,
     test_username: str,
@@ -54,7 +53,6 @@ async def test_client_retry(
         ).status_code == codes.OK, "request failed with firebolt client"
 
 
-@mark.asyncio
 async def test_client_different_auths(
     httpx_mock: HTTPXMock,
     check_credentials_callback: Callable,
@@ -99,7 +97,6 @@ async def test_client_different_auths(
     ), "invalid auth validation error message"
 
 
-@mark.asyncio
 async def test_client_account_id(
     httpx_mock: HTTPXMock,
     test_username: str,

--- a/tests/unit/common/test_util.py
+++ b/tests/unit/common/test_util.py
@@ -1,7 +1,7 @@
 from asyncio import run
 from threading import Thread
 
-from pytest import mark, raises
+from pytest import raises
 
 from firebolt.utils.util import async_to_sync
 
@@ -52,7 +52,6 @@ def test_async_to_sync_after_run():
         async_to_sync(task)()
 
 
-@mark.asyncio
 async def test_nested_loops() -> None:
     """async_to_sync works correctly inside a running loop."""
 


### PR DESCRIPTION
Set the `asyncio_mode` to `auto` in `setup.cfg` and removed all `@pytest.mark.asyncio` decorators. All tests still pass.