### PR TITLE
ci: Using service account

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ from os import environ
 from pytest import fixture
 from pytest_asyncio import fixture as async_fixture
 
+from firebolt.client.auth import ServiceAccount, UsernamePassword
 from firebolt.service.manager import Settings
 
 LOGGER = getLogger(__name__)
@@ -90,3 +91,13 @@ def service_id() -> str:
 @fixture(scope="session")
 def service_secret() -> str:
     return must_env(SERVICE_SECRET_ENV)
+
+
+@fixture
+def service_auth(service_id, service_secret) -> ServiceAccount:
+    return ServiceAccount(service_id, service_secret)
+
+
+@fixture
+def password_auth(username, password) -> UsernamePassword:
+    return UsernamePassword(username, password)

--- a/tests/integration/dbapi/async/conftest.py
+++ b/tests/integration/dbapi/async/conftest.py
@@ -1,22 +1,22 @@
 from pytest_asyncio import fixture as async_fixture
 
 from firebolt.async_db import Connection, connect
-from firebolt.client.auth import ServiceAccount
+from firebolt.client.auth import ServiceAccount, UsernamePassword
 
 
 @async_fixture
 async def connection(
     engine_url: str,
     database_name: str,
-    service_id: str,
-    service_secret: str,
+    username: str,
+    password: str,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     async with await connect(
         engine_url=engine_url,
         database=database_name,
-        auth=ServiceAccount(service_id, service_secret),
+        auth=UsernamePassword(username, password),
         account_name=account_name,
         api_endpoint=api_endpoint,
     ) as connection:

--- a/tests/integration/dbapi/async/conftest.py
+++ b/tests/integration/dbapi/async/conftest.py
@@ -1,22 +1,22 @@
 from pytest_asyncio import fixture as async_fixture
 
 from firebolt.async_db import Connection, connect
-from firebolt.client.auth import ServiceAccount, UsernamePassword
+from firebolt.client.auth import ServiceAccount
 
 
 @async_fixture
 async def connection(
     engine_url: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_id: str,
+    service_secret: str,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     async with await connect(
         engine_url=engine_url,
         database=database_name,
-        auth=UsernamePassword(username, password),
+        auth=ServiceAccount(service_id, service_secret),
         account_name=account_name,
         api_endpoint=api_endpoint,
     ) as connection:

--- a/tests/integration/dbapi/async/conftest.py
+++ b/tests/integration/dbapi/async/conftest.py
@@ -1,22 +1,21 @@
 from pytest_asyncio import fixture as async_fixture
 
 from firebolt.async_db import Connection, connect
-from firebolt.client.auth import ServiceAccount, UsernamePassword
+from firebolt.client.auth.base import Auth
 
 
 @async_fixture
-async def connection(
+async def username_password_connection(
     engine_url: str,
     database_name: str,
-    username: str,
-    password: str,
+    password_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     async with await connect(
         engine_url=engine_url,
         database=database_name,
-        auth=UsernamePassword(username, password),
+        auth=password_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     ) as connection:
@@ -24,18 +23,17 @@ async def connection(
 
 
 @async_fixture
-async def service_account_connection(
+async def connection(
     engine_url: str,
     database_name: str,
-    service_id: str,
-    service_secret: str,
+    service_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     async with await connect(
         engine_url=engine_url,
         database=database_name,
-        auth=ServiceAccount(service_id, service_secret),
+        auth=service_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     ) as connection:
@@ -46,8 +44,7 @@ async def service_account_connection(
 async def connection_engine_name(
     engine_name: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
@@ -55,8 +52,7 @@ async def connection_engine_name(
     async with await connect(
         engine_name=engine_name,
         database=database_name,
-        username=username,
-        password=password,
+        auth=service_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     ) as connection:
@@ -66,16 +62,14 @@ async def connection_engine_name(
 @async_fixture
 async def connection_no_engine(
     database_name: str,
-    username: str,
-    password: str,
+    service_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
 
     async with await connect(
         database=database_name,
-        username=username,
-        password=password,
+        auth=service_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     ) as connection:

--- a/tests/integration/dbapi/async/test_auth_async.py
+++ b/tests/integration/dbapi/async/test_auth_async.py
@@ -29,11 +29,11 @@ async def test_refresh_token(connection: Connection) -> None:
 
 
 async def test_credentials_invalidation(
-    connection: Connection, service_account_connection: Connection
+    connection: Connection, username_password_connection: Connection
 ) -> None:
     """Auth raises authentication error on credentials invalidation"""
     # Can't pytest.parametrize it due to nested event loop error
-    for conn in [connection, service_account_connection]:
+    for conn in [connection, username_password_connection]:
         with conn.cursor() as c:
             # Works fine
             await c.execute("show tables")

--- a/tests/integration/dbapi/sync/conftest.py
+++ b/tests/integration/dbapi/sync/conftest.py
@@ -1,22 +1,21 @@
 from pytest import fixture
 
-from firebolt.client.auth import ServiceAccount, UsernamePassword
+from firebolt.client.auth.base import Auth
 from firebolt.db import Connection, connect
 
 
 @fixture
-def connection(
+def username_password_connection(
     engine_url: str,
     database_name: str,
-    username: str,
-    password: str,
+    password_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     connection = connect(
         engine_url=engine_url,
         database=database_name,
-        auth=UsernamePassword(username, password),
+        auth=password_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     )
@@ -25,18 +24,17 @@ def connection(
 
 
 @fixture
-async def service_account_connection(
+async def connection(
     engine_url: str,
     database_name: str,
-    service_id: str,
-    service_secret: str,
+    service_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     connection = connect(
         engine_url=engine_url,
         database=database_name,
-        auth=ServiceAccount(service_id, service_secret),
+        auth=service_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     )
@@ -48,16 +46,14 @@ async def service_account_connection(
 def connection_engine_name(
     engine_name: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     connection = connect(
         engine_name=engine_name,
         database=database_name,
-        username=username,
-        password=password,
+        auth=service_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     )
@@ -68,15 +64,13 @@ def connection_engine_name(
 @fixture
 def connection_no_engine(
     database_name: str,
-    username: str,
-    password: str,
+    service_auth: Auth,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     connection = connect(
         database=database_name,
-        username=username,
-        password=password,
+        auth=service_auth,
         account_name=account_name,
         api_endpoint=api_endpoint,
     )

--- a/tests/integration/dbapi/sync/conftest.py
+++ b/tests/integration/dbapi/sync/conftest.py
@@ -1,6 +1,6 @@
 from pytest import fixture
 
-from firebolt.client.auth import ServiceAccount, UsernamePassword
+from firebolt.client.auth import ServiceAccount
 from firebolt.db import Connection, connect
 
 
@@ -8,15 +8,15 @@ from firebolt.db import Connection, connect
 def connection(
     engine_url: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_id: str,
+    service_secret: str,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     connection = connect(
         engine_url=engine_url,
         database=database_name,
-        auth=UsernamePassword(username, password),
+        auth=ServiceAccount(service_id, service_secret),
         account_name=account_name,
         api_endpoint=api_endpoint,
     )

--- a/tests/integration/dbapi/sync/conftest.py
+++ b/tests/integration/dbapi/sync/conftest.py
@@ -1,6 +1,6 @@
 from pytest import fixture
 
-from firebolt.client.auth import ServiceAccount
+from firebolt.client.auth import ServiceAccount, UsernamePassword
 from firebolt.db import Connection, connect
 
 
@@ -8,15 +8,15 @@ from firebolt.db import Connection, connect
 def connection(
     engine_url: str,
     database_name: str,
-    service_id: str,
-    service_secret: str,
+    username: str,
+    password: str,
     account_name: str,
     api_endpoint: str,
 ) -> Connection:
     connection = connect(
         engine_url=engine_url,
         database=database_name,
-        auth=ServiceAccount(service_id, service_secret),
+        auth=UsernamePassword(username, password),
         account_name=account_name,
         api_endpoint=api_endpoint,
     )

--- a/tests/integration/dbapi/sync/test_auth.py
+++ b/tests/integration/dbapi/sync/test_auth.py
@@ -28,7 +28,7 @@ def test_refresh_token(connection: Connection) -> None:
         assert c._client.auth.token != old, "Auth didn't update token on expiration"
 
 
-@mark.parametrize("connection_fixture", ["connection", "service_account_connection"])
+@mark.parametrize("connection_fixture", ["connection", "username_password_connection"])
 def test_credentials_invalidation(connection_fixture: str, request) -> None:
     """Auth raises Authentication Error on credentials invalidation"""
     with request.getfixturevalue(connection_fixture).cursor() as c:

--- a/tests/integration/dbapi/sync/test_errors.py
+++ b/tests/integration/dbapi/sync/test_errors.py
@@ -1,10 +1,10 @@
 from httpx import ConnectError
 from pytest import mark, raises
 
+from firebolt.client.auth import ServiceAccount, UsernamePassword
 from firebolt.db import Connection, connect
 from firebolt.utils.exception import (
     AccountNotFoundError,
-    AuthenticationError,
     EngineNotRunningError,
     FireboltDatabaseError,
     FireboltEngineError,
@@ -12,30 +12,10 @@ from firebolt.utils.exception import (
 )
 
 
-def test_invalid_credentials(
-    engine_url: str, database_name: str, username: str, password: str, api_endpoint: str
-) -> None:
-    """Connection properly reacts to invalid credentials error."""
-    with connect(
-        engine_url=engine_url,
-        database=database_name,
-        username=username + "_",
-        password=password + "_",
-        api_endpoint=api_endpoint,
-    ) as connection:
-        with raises(AuthenticationError) as exc_info:
-            connection.cursor().execute("show tables")
-
-        assert str(exc_info.value).startswith(
-            "Failed to authenticate"
-        ), "Invalid authentication error message"
-
-
 def test_invalid_account(
     database_name: str,
     engine_name: str,
-    username: str,
-    password: str,
+    password_auth: UsernamePassword,
     api_endpoint: str,
 ) -> None:
     """Connection properly reacts to invalid account error."""
@@ -44,8 +24,7 @@ def test_invalid_account(
         with connect(
             database=database_name,
             engine_name=engine_name,  # Omit engine_url to force account_id lookup.
-            username=username,
-            password=password,
+            auth=password_auth,
             account_name=account_name,
             api_endpoint=api_endpoint,
         ) as connection:
@@ -57,14 +36,13 @@ def test_invalid_account(
 
 
 def test_engine_url_not_exists(
-    engine_url: str, database_name: str, username: str, password: str, api_endpoint: str
+    engine_url: str, database_name: str, service_auth: ServiceAccount, api_endpoint: str
 ) -> None:
     """Connection properly reacts to invalid engine url error."""
     with connect(
         engine_url=engine_url + "_",
         database=database_name,
-        username=username,
-        password=password,
+        auth=service_auth,
         api_endpoint=api_endpoint,
     ) as connection:
         with raises(ConnectError):
@@ -74,8 +52,7 @@ def test_engine_url_not_exists(
 def test_engine_name_not_exists(
     engine_name: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_auth: ServiceAccount,
     api_endpoint: str,
 ) -> None:
     """Connection properly reacts to invalid engine name error."""
@@ -83,8 +60,7 @@ def test_engine_name_not_exists(
         with connect(
             engine_name=engine_name + "_________",
             database=database_name,
-            username=username,
-            password=password,
+            auth=service_auth,
             api_endpoint=api_endpoint,
         ) as connection:
             connection.cursor().execute("show tables")
@@ -93,8 +69,7 @@ def test_engine_name_not_exists(
 def test_engine_stopped(
     stopped_engine_url: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_auth: ServiceAccount,
     api_endpoint: str,
 ) -> None:
     """Connection properly reacts to engine not running error."""
@@ -102,8 +77,7 @@ def test_engine_stopped(
         with connect(
             engine_url=stopped_engine_url,
             database=database_name,
-            username=username,
-            password=password,
+            auth=service_auth,
             api_endpoint=api_endpoint,
         ) as connection:
             connection.cursor().execute("show tables")
@@ -111,15 +85,14 @@ def test_engine_stopped(
 
 @mark.skip(reason="Behaviour is different in prod vs dev")
 def test_database_not_exists(
-    engine_url: str, database_name: str, username: str, password: str, api_endpoint: str
+    engine_url: str, database_name: str, service_auth: ServiceAccount, api_endpoint: str
 ) -> None:
     """Connection properly reacts to invalid database error."""
     new_db_name = database_name + "_"
     with connect(
         engine_url=engine_url,
         database=new_db_name,
-        username=username,
-        password=password,
+        auth=service_auth,
         api_endpoint=api_endpoint,
     ) as connection:
         with raises(FireboltDatabaseError) as exc_info:

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -7,7 +7,7 @@ from pytest import mark, raises
 
 from firebolt.async_db._types import ColType, Column
 from firebolt.async_db.cursor import QueryStatus
-from firebolt.client.auth import UsernamePassword
+from firebolt.client.auth import ServiceAccount
 from firebolt.db import (
     Connection,
     Cursor,
@@ -379,8 +379,8 @@ def test_set_invalid_parameter(connection: Connection):
 def test_anyio_backend_import_issue(
     engine_url: str,
     database_name: str,
-    username: str,
-    password: str,
+    service_id: str,
+    service_secret: str,
     account_name: str,
     api_endpoint: str,
     _: int,
@@ -391,10 +391,10 @@ def test_anyio_backend_import_issue(
     exceptions = []
 
     def run_query(idx: int):
-        nonlocal username, password, database_name, engine_url, account_name, api_endpoint
+        nonlocal service_id, service_secret, database_name, engine_url, account_name, api_endpoint
         try:
             with connect(
-                auth=UsernamePassword(username, password),
+                auth=ServiceAccount(service_id, service_secret),
                 database=database_name,
                 account_name=account_name,
                 engine_url=engine_url,


### PR DESCRIPTION
Using service account for CI leads to less errors from the backend and avoids being blocked by the rate limiter.

Removing `test_invalid_credentials` since the same functionality is tested in `test_credentials_invalidation`

Functionality is confirmed by running integration test workflow on this branch.