### PR TITLE
docs: Clarify thread safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Optional parameters
 ## Examples
 See [PEP-249](https://www.python.org/dev/peps/pep-0249) for the DB API reference and specifications. An example [jupyter notebook](https://github.com/firebolt-db/firebolt-sdk/tree/main/examples/dbapi.ipynb) is included to illustrate the use of the Firebolt API.
 
+## Special considerations
+### Cursor objects should not be shared between threads
+Cursor is not thread-safe and should not be shared across threads. In a multi-threaded environment you can share a Connection, but each thread would need to keep its own Cursor. This corresponds to a thread safety 2 in the [DBApi specification](https://peps.python.org/pep-0249/#threadsafety).
+
 ## Optional features
 ### Faster datetime with ciso8601
 By default, firebolt-sdk uses `datetime` module to parse date and datetime values, which might be slow for a large amount of operations. In order to speed up datetime operations, it's possible to use [ciso8601](https://pypi.org/project/ciso8601/) package. In order to install firebolt-sdk with `ciso8601` support, run `pip install "firebolt-sdk[ciso8601]"`

--- a/src/firebolt/async_db/__init__.py
+++ b/src/firebolt/async_db/__init__.py
@@ -32,5 +32,5 @@ from firebolt.utils.exception import (
 
 apilevel = "2.0"
 # threads may only share the module and connections, cursors should not be shared
-threadsafety = 1
+threadsafety = 2
 paramstyle = "qmark"

--- a/src/firebolt/db/__init__.py
+++ b/src/firebolt/db/__init__.py
@@ -31,5 +31,6 @@ from firebolt.utils.exception import (
 )
 
 apilevel = "2.0"
-threadsafety = 3  # threads may share the module, connections and cursors
+# threads may only share the module and connections, cursors should not be shared
+threadsafety = 2
 paramstyle = "qmark"


### PR DESCRIPTION
As a recent issue showed, sharing a cursor in a multi-threaded environment is not safe. The issue stems from asyncio not playing nicely in such environment. Moreover, this also leads to a confusion on query result retention - if several queries run at the same time it's not deterministic which query's result will be stored (also its success status). Therefore the best practice is not to share cursors at all.