### PR TITLE
feat: use trio for async_to_sync

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     pydantic[dotenv]>=1.8.2,<1.10
     readerwriterlock==1.0.9
     sqlparse>=0.4.2
+    trio
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ dev =
     pytest-mock==3.6.1
     pytest-timeout==2.1.0
     pytest-xdist==2.5.0
+    trio-typing[mypy]==0.6.*
     types-cryptography==3.3.18
 
 [options.package_data]

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -679,7 +679,7 @@ class BaseCursor:
 
 class Cursor(BaseCursor):
     """
-    Executes asyncio queries to Firebolt Database.
+    Executes async queries to Firebolt Database.
     Should not be created directly;
     use :py:func:`connection.cursor <firebolt.async_db.connection.Connection>`
 

--- a/src/firebolt/utils/util.py
+++ b/src/firebolt/utils/util.py
@@ -1,22 +1,7 @@
-from asyncio import (
-    AbstractEventLoop,
-    get_event_loop,
-    new_event_loop,
-    set_event_loop,
-)
 from functools import lru_cache, partial, wraps
-from threading import Thread
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    Optional,
-    Type,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Callable, Type, TypeVar
 
-import trio  # type: ignore
+import trio
 from httpx import URL
 
 T = TypeVar("T")
@@ -85,81 +70,11 @@ def fix_url_schema(url: str) -> str:
     return url if url.startswith("http") else f"https://{url}"
 
 
-class AsyncJobThread:
-    """Thread runner that allows running async tasks synchronously in a separate thread.
-
-    Caches loop to be reused in all threads.
-    It allows running async functions synchronously inside a running event loop.
-    Since nesting loops is not allowed, we create a separate thread for a new event loop
-
-    Attributes:
-        result (Any): Value, returned by coroutine execution
-        exception (Optional[BaseException]): If any, exception that occurred
-            during coroutine execution
-    """
-
-    def __init__(self) -> None:
-        self._loop: Optional[AbstractEventLoop] = None
-        self.result: Any = None
-        self.exception: Optional[BaseException] = None
-
-    def _initialize_loop(self) -> None:
-        """Initialize a loop once to use for later execution.
-
-        Tries to get a running loop.
-        Creates a new loop if no active one, and sets it as active.
-        """
-        if not self._loop:
-            try:
-                # despite the docs, this function fails if no loop is set
-                self._loop = get_event_loop()
-            except RuntimeError:
-                self._loop = new_event_loop()
-        set_event_loop(self._loop)
-
-    def _run(self, coro: Coroutine) -> None:
-        """Run coroutine in an event loop.
-
-        Execution return value is stored into ``result`` field.
-        If an exception occurs, it will be caught and stored into ``exception`` field.
-
-        Args:
-            coro (Coroutine): Coroutine to execute
-        """
-        try:
-            self._initialize_loop()
-            assert self._loop is not None
-            self.result = self._loop.run_until_complete(coro)
-        except BaseException as e:
-            self.exception = e
-
-    def execute(self, coro: Coroutine) -> Any:
-        """Execute coroutine in a separate thread.
-
-        Args:
-            coro (Coroutine): Coroutine to execute
-
-        Returns:
-            Any: Coroutine execution return value
-
-        Raises:
-            exception: Exeption, occured within coroutine
-        """
-        thread = Thread(target=self._run, args=[coro])
-        thread.start()
-        thread.join()
-        if self.exception:
-            raise self.exception
-        return self.result
-
-
-def async_to_sync(f: Callable, async_job_thread: AsyncJobThread = None) -> Callable:
+def async_to_sync(f: Callable) -> Callable:
     """Convert async function to sync.
 
     Args:
         f (Callable): function to convert
-        async_job_thread (AsyncJobThread): Job thread instance to use for async excution
-            (Default value = None)
 
     Returns:
         Callable: regular function, which can be executed synchronously

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -473,6 +473,12 @@ def test_multi_thread_connection_sharing(
     account_name: str,
     api_endpoint: str,
 ) -> None:
+    """
+    Test to verify sharing the same connection between different
+    threads works. With asyncio synching an async function this used
+    to fail due to a different loop having exclusive rights to the
+    Httpx client. Trio fixes this issue.
+    """
 
     exceptions = []
 


### PR DESCRIPTION
Asyncio prevents us from sharing Connection objects across threads due to registering httpx Client to the main thread's loop.  Trio seems to solve this problem, as confirmed in the integration test I've added. Looks like there's no impact on the rest of the functionality.