### PR TITLE
build: limit Trio version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     pydantic[dotenv]>=1.8.2,<1.10
     readerwriterlock==1.0.9
     sqlparse>=0.4.2
-    trio
+    trio<0.22.0
 python_requires = >=3.7
 include_package_data = True
 package_dir =


### PR DESCRIPTION
Currently the latest version of anyio does not support trio 0.22.0 and raises warnings. In order to reduce the verbosity of our sdk I'm limiting trio to 0.21.0. This does not affect any of the sdk functions, as confirmed by the integration tests.
More info in https://packboard.atlassian.net/browse/FIR-17043
