### PR TITLE
test: Fix integration tests

### DIFF
--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -130,7 +130,6 @@ async def test_select(
 ) -> None:
     """Select handles all data types properly."""
     with connection.cursor() as c:
-        assert (await c.execute("set firebolt_use_decimal = 1")) == -1
         assert await c.execute(all_types_query) == 1, "Invalid row count returned"
         assert c.rowcount == 1, "Invalid rowcount value"
         data = await c.fetchall()
@@ -310,7 +309,6 @@ async def test_parameterized_query(connection: Connection) -> None:
             await c.fetchall()
 
     with connection.cursor() as c:
-        await c.execute("set firebolt_use_decimal = 1")
         await c.execute("DROP TABLE IF EXISTS test_tb_async_parameterized")
         await c.execute(
             "CREATE FACT TABLE test_tb_async_parameterized(i int, f float, s string, sn"

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -89,7 +89,6 @@ def test_select(
 ) -> None:
     """Select handles all data types properly."""
     with connection.cursor() as c:
-        assert c.execute("set firebolt_use_decimal = 1") == -1
         assert c.execute(all_types_query) == 1, "Invalid row count returned"
         assert c.rowcount == 1, "Invalid rowcount value"
         data = c.fetchall()
@@ -263,7 +262,6 @@ def test_parameterized_query(connection: Connection) -> None:
             c.fetchall()
 
     with connection.cursor() as c:
-        c.execute("set firebolt_use_decimal = 1")
         c.execute("DROP TABLE IF EXISTS test_tb_parameterized")
         c.execute(
             "CREATE FACT TABLE test_tb_parameterized(i int, f float, s string, sn"

--- a/tests/integration/dbapi/sync/test_system_engine.py
+++ b/tests/integration/dbapi/sync/test_system_engine.py
@@ -137,3 +137,10 @@ def test_start_stop_engine(setup_dbs, connection_system_engine, engine_name):
         check_engine_status(cursor, engine_name, "Running")
         cursor.execute(f"STOP ENGINE {engine_name}")
         check_engine_status(cursor, engine_name, "Stopped")
+
+
+@mark.xdist_group(name="system_engine")
+def test_select_one(connection_system_engine):
+    """SELECT statements are supported"""
+    with connection_system_engine.cursor() as cursor:
+        cursor.execute("SELECT 1")

--- a/tests/integration/dbapi/sync/test_system_engine.py
+++ b/tests/integration/dbapi/sync/test_system_engine.py
@@ -68,7 +68,7 @@ def db_specs(region, attached_engine):
 
 @mark.parametrize(
     "query",
-    ["SELECT 1", "CREATE DIMENSION TABLE dummy(id INT)", "SHOW TABLES", "SHOW INDEXES"],
+    ["CREATE DIMENSION TABLE dummy(id INT)", "SHOW TABLES", "SHOW INDEXES"],
 )
 def test_query_errors(connection_system_engine, query):
     with connection_system_engine.cursor() as cursor:


### PR DESCRIPTION
Made a couple of changes in order to fix integration tests
- removed outdated `firebolt_use_decimal` flag. This seems to be the default behavior now
- remove `select 1` from expected to fail statements for system engine. System engine seems to support this statements now
The last integration tests run was successful: https://github.com/firebolt-db/firebolt-python-sdk/actions/runs/3901616576