### PR TITLE
chore: Relax pydantic version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     appdirs-stubs>=0.1.0
     cryptography>=3.4.0
     httpx[http2]==0.23.0
-    pydantic[dotenv]>=1.8.2,<1.10
+    pydantic[dotenv]>=1.8.2
     python-dateutil>=2.8.2
     readerwriterlock==1.0.9
     sqlparse>=0.4.2

--- a/src/firebolt/common/settings.py
+++ b/src/firebolt/common/settings.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from pydantic import BaseSettings, Field, SecretStr, root_validator
 
@@ -33,14 +34,14 @@ class Settings(BaseSettings):
         default_region (str): Default region for provisioning
     """
 
-    auth: Auth = Field(...)
+    auth: Optional[Auth] = Field(None)
     # Authorization
-    user: str = Field(..., env="FIREBOLT_USER")
-    password: SecretStr = Field(..., env="FIREBOLT_PASSWORD")
+    user: Optional[str] = Field(None, env="FIREBOLT_USER")
+    password: Optional[SecretStr] = Field(None, env="FIREBOLT_PASSWORD")
     # Or
-    access_token: str = Field(..., env="FIREBOLT_AUTH_TOKEN")
+    access_token: Optional[str] = Field(None, env="FIREBOLT_AUTH_TOKEN")
 
-    account_name: str = Field(..., env="FIREBOLT_ACCOUNT")
+    account_name: Optional[str] = Field(None, env="FIREBOLT_ACCOUNT")
     server: str = Field(..., env="FIREBOLT_SERVER")
     default_region: str = Field(..., env="FIREBOLT_DEFAULT_REGION")
     use_token_cache: bool = Field(True)

--- a/src/firebolt/common/settings.py
+++ b/src/firebolt/common/settings.py
@@ -33,14 +33,14 @@ class Settings(BaseSettings):
         default_region (str): Default region for provisioning
     """
 
-    auth: Auth = Field(None)
+    auth: Auth = Field(...)
     # Authorization
-    user: str = Field(None, env="FIREBOLT_USER")
-    password: SecretStr = Field(None, env="FIREBOLT_PASSWORD")
+    user: str = Field(..., env="FIREBOLT_USER")
+    password: SecretStr = Field(..., env="FIREBOLT_PASSWORD")
     # Or
-    access_token: str = Field(None, env="FIREBOLT_AUTH_TOKEN")
+    access_token: str = Field(..., env="FIREBOLT_AUTH_TOKEN")
 
-    account_name: str = Field(None, env="FIREBOLT_ACCOUNT")
+    account_name: str = Field(..., env="FIREBOLT_ACCOUNT")
     server: str = Field(..., env="FIREBOLT_SERVER")
     default_region: str = Field(..., env="FIREBOLT_DEFAULT_REGION")
     use_token_cache: bool = Field(True)

--- a/src/firebolt/model/database.py
+++ b/src/firebolt/model/database.py
@@ -45,9 +45,9 @@ class Database(FireboltBaseModel):
     compute_region_key: RegionKey = Field(alias="compute_region_id")
 
     # optional
-    database_key: Optional[DatabaseKey] = Field(alias="id")
-    description: Optional[str] = Field(max_length=255)
-    emoji: Optional[str] = Field(max_length=255)
+    database_key: Optional[DatabaseKey] = Field(None, alias="id")
+    description: Optional[str] = Field(None, max_length=255)
+    emoji: Optional[str] = Field(None, max_length=255)
     current_status: Optional[str]
     health_status: Optional[str]
     data_size_full: Optional[int]

--- a/src/firebolt/model/engine.py
+++ b/src/firebolt/model/engine.py
@@ -122,15 +122,17 @@ class Engine(FireboltBaseModel):
     settings: EngineSettings
 
     # optional
-    key: Optional[EngineKey] = Field(alias="id")
+    key: Optional[EngineKey] = Field(None, alias="id")
     description: Optional[str]
     emoji: Optional[str]
     current_status: Optional[EngineStatus]
     current_status_summary: Optional[EngineStatusSummary]
-    latest_revision_key: Optional[EngineRevisionKey] = Field(alias="latest_revision_id")
+    latest_revision_key: Optional[EngineRevisionKey] = Field(
+        None, alias="latest_revision_id"
+    )
     endpoint: Optional[str]
     endpoint_serving_revision_key: Optional[EngineRevisionKey] = Field(
-        alias="endpoint_serving_revision_id"
+        None, alias="endpoint_serving_revision_id"
     )
     create_time: Optional[datetime]
     create_actor: Optional[str]
@@ -140,7 +142,7 @@ class Engine(FireboltBaseModel):
     desired_status: Optional[str]
     health_status: Optional[str]
     endpoint_desired_revision_key: Optional[EngineRevisionKey] = Field(
-        alias="endpoint_desired_revision_id"
+        None, alias="endpoint_desired_revision_id"
     )
 
     @classmethod

--- a/src/firebolt/model/engine_revision.py
+++ b/src/firebolt/model/engine_revision.py
@@ -48,7 +48,7 @@ class EngineRevision(FireboltBaseModel):
     specification: EngineRevisionSpecification
 
     # optional
-    key: Optional[EngineRevisionKey] = Field(alias="id")
+    key: Optional[EngineRevisionKey] = Field(None, alias="id")
     current_status: Optional[str]
     create_time: Optional[datetime]
     create_actor: Optional[str]

--- a/src/firebolt/service/manager.py
+++ b/src/firebolt/service/manager.py
@@ -36,6 +36,9 @@ class ResourceManager:
             if self.settings.access_token:
                 auth = Token(self.settings.access_token)
             else:
+                # mypy checks
+                assert self.settings.user
+                assert self.settings.password
                 auth = UsernamePassword(
                     self.settings.user,
                     self.settings.password.get_secret_value(),


### PR DESCRIPTION
Released `pydantic` version to allow `>=1.10` (https://github.com/firebolt-db/firebolt-python-sdk/issues/227)
Added some changes to field definitions in order to support it