### PR TITLE
ci: New slack notification action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,14 +67,45 @@ jobs:
           API_ENDPOINT: "api.staging.firebolt.io"
         run: |
           pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=INFO tests/integration
-        
+
       - name: Slack Notify of failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.2.0
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # Slack channel id, channel name, or user id to post message.
+          channel-id: 'test-ci-notifications-ptiurin'
+          # https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "text": "GitHub Nightly has failed HEADER",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "emoji": true,
+                    "text": "Nightly has failed :sadparrot:"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:* ${{ github.event.repository.name }}\n*Link:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GH Action>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*OS:* ${{ matrix.os }}\n*Python version:* ${{ matrix.python-version }}"
+                    }
+                  ]
+                }
+              ]
+            }
+
         env:
-          SLACK_USERNAME: CI bot
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_COLOR: "#FF0000"
-          SLACK_ICON: None
-          SLACK_TITLE: Nightly tests failed
-          SLACK_MESSAGE: Please investigate
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,7 @@ jobs:
           pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=INFO tests/integration
 
       - name: Slack Notify of failure
+        if: failure()
         id: slack
         uses: firebolt-db/action-slack-nightly-notify@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
-      matrix: 
+      matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
 
-      - name: Test with pytest
+      - name: Unit test with pytest
         run: |
           pytest tests/unit
 
@@ -69,43 +69,11 @@ jobs:
           pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=INFO tests/integration
 
       - name: Slack Notify of failure
-        if: failure()
         id: slack
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: firebolt-db/action-slack-nightly-notify@v1
         with:
-          # Slack channel id, channel name, or user id to post message.
-          channel-id: 'test-ci-notifications-ptiurin'
-          # https://api.slack.com/reference/block-kit
-          payload: |
-            {
-              "text": "GitHub Nightly has failed HEADER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "emoji": true,
-                    "text": "Nightly has failed :sadparrot:"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Repository:* ${{ github.event.repository.name }}\n*Link:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GH Action>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*OS:* ${{ matrix.os }}\n*Python version:* ${{ matrix.python-version }}"
-                    }
-                  ]
-                }
-              ]
-            }
-
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          os: ${{ matrix.os }}
+          programming-language: Python
+          language-version: ${{ matrix.python-version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Improving our slack reporting app by migrating to an action implemented in JS. This allows it to run on all platforms, thus reporting all the failures in nightlies we might get.
Also, adding some better info to see what failed at a glance:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/93913847/217783377-59161913-77bf-47c2-b8f8-cb5cdcbeadd6.png">
