### PR TITLE
fix: Decimal class type compatibility

### DIFF
--- a/src/firebolt/async_db/_types.py
+++ b/src/firebolt/async_db/_types.py
@@ -125,6 +125,7 @@ class ARRAY:
 class DECIMAL:
     """Class for holding `decimal` value information in Firebolt DB."""
 
+    __name__ = "Decimal"
     _prefix = "Decimal("
 
     def __init__(self, precision: int, scale: int):

--- a/src/firebolt/async_db/_types.py
+++ b/src/firebolt/async_db/_types.py
@@ -105,6 +105,7 @@ Column = namedtuple(
 class ARRAY:
     """Class for holding `array` column type information in Firebolt DB."""
 
+    __name__ = "Array"
     _prefix = "array("
 
     def __init__(self, subtype: Union[type, ARRAY, DECIMAL]):


### PR DESCRIPTION
`__name__` attribute is used in DBT to map python class to SQL query.
This is needed for https://github.com/firebolt-db/dbt-firebolt/pull/95