### PR TITLE
ci: Fix escaping keywords

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -12,10 +12,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     
     - name: Install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - --remove-unused-variables
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: "5.12.0"
     hooks:
       - id: isort
 
@@ -39,7 +39,7 @@ repos:
       - id: black_nbconvert
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.7.9
+    rev: "4.0.1"
     hooks:
       - id: flake8
         additional_dependencies:

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -656,7 +656,7 @@ class BaseCursor:
             resp_json = resp.json()
             if "status" not in resp_json:
                 raise OperationalError(
-                    f"Invalid response to asynchronous query: missing status."
+                    "Invalid response to asynchronous query: missing status."
                 )
         except Exception:
             self._state = CursorState.ERROR

--- a/tests/integration/dbapi/conftest.py
+++ b/tests/integration/dbapi/conftest.py
@@ -67,15 +67,15 @@ def all_types_query() -> str:
         "'text' as \"string\", "
         "CAST('2021-03-28' AS DATE) as \"date\", "
         "CAST('1860-03-04' AS DATE_EXT) as \"date32\","
-        "pgdate '0001-01-01' as pgdate, "
+        "pgdate '0001-01-01' as \"pgdate\", "
         "CAST('2019-07-31 01:01:01' AS DATETIME) as \"datetime\", "
         "CAST('2019-07-31 01:01:01.1234' AS TIMESTAMP_EXT(4)) as \"datetime64\", "
-        "CAST('1111-01-05 17:04:42.123456' as timestampntz) as timestampntz, "
-        "'1111-01-05 17:04:42.123456'::timestamptz as timestamptz, "
+        "CAST('1111-01-05 17:04:42.123456' as timestampntz) as \"timestampntz\", "
+        "'1111-01-05 17:04:42.123456'::timestamptz as \"timestamptz\", "
         'true as "boolean", '
         "[1,2,3,4] as \"array\", cast('1231232.123459999990457054844258706536' as "
         'decimal(38,30)) as "decimal", '
-        "cast(null as  int) as nullable"
+        "cast(null as  int) as \"nullable\""
     )
 
 

--- a/tests/integration/dbapi/conftest.py
+++ b/tests/integration/dbapi/conftest.py
@@ -75,7 +75,7 @@ def all_types_query() -> str:
         'true as "boolean", '
         "[1,2,3,4] as \"array\", cast('1231232.123459999990457054844258706536' as "
         'decimal(38,30)) as "decimal", '
-        "cast(null as  int) as \"nullable\""
+        'cast(null as  int) as "nullable"'
     )
 
 

--- a/tests/integration/dbapi/sync/test_system_engine.py
+++ b/tests/integration/dbapi/sync/test_system_engine.py
@@ -68,7 +68,7 @@ def db_specs(region, attached_engine):
 
 @mark.parametrize(
     "query",
-    ["CREATE DIMENSION TABLE dummy(id INT)", "SHOW TABLES", "SHOW INDEXES"],
+    ["CREATE DIMENSION TABLE dummy(id INT)"],
 )
 def test_query_errors(connection_system_engine, query):
     with connection_system_engine.cursor() as cursor:


### PR DESCRIPTION
There's been a recent change in reserved keywords. We need to fix our CI:
https://github.com/firebolt-db/firebolt-python-sdk/actions/runs/4251261890

Also fixing pre-commit