### PR TITLE
fix(ResourceManager): no engines attached to db

### DIFF
--- a/src/firebolt/service/binding.py
+++ b/src/firebolt/service/binding.py
@@ -81,6 +81,8 @@ class BindingService(BaseService):
         """Get a list of engines that are bound to a database."""
 
         bindings = self.get_many(database_id=database.database_id)
+        if not bindings:
+            return []
         return self.resource_manager.engines.get_by_ids(
             ids=[b.engine_id for b in bindings]
         )


### PR DESCRIPTION
We do useless api call on `get_attached_engines` to fetch engine info if no engines are bound to a database. This avoids this call returning an empty list straight away.
A call with no engines also breaks now with the recent changes to the API so this also fixes the issue we're having in nightlies.