### PR TITLE
test: Remove insert rowcount test

### DIFF
--- a/tests/integration/dbapi/async/test_queries_async.py
+++ b/tests/integration/dbapi/async/test_queries_async.py
@@ -382,15 +382,11 @@ async def test_multi_statement_query(connection: Connection) -> None:
             " primary index i"
         )
 
-        assert (
-            await c.execute(
-                "INSERT INTO test_tb_async_multi_statement values (1, 'a'), (2, 'b');"
-                "SELECT * FROM test_tb_async_multi_statement;"
-                "SELECT * FROM test_tb_async_multi_statement WHERE i <= 1"
-            )
-            == 1  # Insert always returns 1 row with num of rows modified
-        ), "Invalid row count returned for insert"
-        assert c.rowcount == 1, "Invalid row count"
+        await c.execute(
+            "INSERT INTO test_tb_async_multi_statement values (1, 'a'), (2, 'b');"
+            "SELECT * FROM test_tb_async_multi_statement;"
+            "SELECT * FROM test_tb_async_multi_statement WHERE i <= 1"
+        )
         assert c.description is None, "Invalid description"
 
         assert await c.nextset()

--- a/tests/integration/dbapi/sync/test_queries.py
+++ b/tests/integration/dbapi/sync/test_queries.py
@@ -327,15 +327,11 @@ def test_multi_statement_query(connection: Connection) -> None:
             "CREATE FACT TABLE test_tb_multi_statement(i int, s string) primary index i"
         )
 
-        assert (
-            c.execute(
-                "INSERT INTO test_tb_multi_statement values (1, 'a'), (2, 'b');"
-                "SELECT * FROM test_tb_multi_statement;"
-                "SELECT * FROM test_tb_multi_statement WHERE i <= 1"
-            )
-            == 1  # Insert always returns 1 row with num of rows modified
-        ), "Invalid row count returned for insert"
-        assert c.rowcount == 1, "Invalid row count"
+        c.execute(
+            "INSERT INTO test_tb_multi_statement values (1, 'a'), (2, 'b');"
+            "SELECT * FROM test_tb_multi_statement;"
+            "SELECT * FROM test_tb_multi_statement WHERE i <= 1"
+        )
         assert c.description is None, "Invalid description"
 
         assert c.nextset()


### PR DESCRIPTION
This test is flaky as result of an Insert query is one element array with the number of rows affected (as explained by the aragog team), but this is not implemented yet. The actual rowcount value we test here changes as the backend returns slightly different results. We can't really test this until the insert rowcount is implemented so I'm removing those tests altogether.
Rowcount for select queries is still correct.