### PR TITLE
lock pydantic version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     appdirs-stubs>=0.1.0
     cryptography>=3.4.0
     httpx[http2]==0.24.0
-    pydantic[dotenv]>=1.8.2
+    pydantic[dotenv]>=1.8.2,<=1.10.10
     python-dateutil>=2.8.2
     readerwriterlock==1.0.9
     sqlparse>=0.4.2


### PR DESCRIPTION
Lock pydantic version to 1.* to avoid incompatibility issues