### PR TITLE
ci: disable tests before release

### DIFF
--- a/.github/workflows/release-v0.yml
+++ b/.github/workflows/release-v0.yml
@@ -11,21 +11,21 @@ on:
         description: 'Trigger a major release (optional). Leave empty for regular release.'
 
 jobs:
-  integration-tests:
-    uses: ./.github/workflows/integration-tests.yml
-    with:
-      branch: 0.x
-    secrets:
-      FIREBOLT_USERNAME: ${{ secrets.FIREBOLT_USERNAME }}
-      FIREBOLT_PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
-      SERVICE_ID: ${{ secrets.SERVICE_ID }}
-      SERVICE_SECRET: ${{ secrets.SERVICE_SECRET }}
+  # integration-tests:
+  #   uses: ./.github/workflows/integration-tests.yml
+  #   with:
+  #     branch: 0.x
+  #   secrets:
+  #     FIREBOLT_USERNAME: ${{ secrets.FIREBOLT_USERNAME }}
+  #     FIREBOLT_PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
+  #     SERVICE_ID: ${{ secrets.SERVICE_ID }}
+  #     SERVICE_SECRET: ${{ secrets.SERVICE_SECRET }}
 
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: integration-tests
+#    needs: integration-tests
     steps:
     - name: Check out code
       uses: actions/checkout@v2


### PR DESCRIPTION
Temporary disable integration tests before release to unloop