### PR TITLE
feat: Performance debug info

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     async-generator>=1.10
     async-property>=0.2.1
     cryptography>=3.4.0
+	httpcore<0.17.3
     httpx[http2]==0.24.0
     python-dateutil>=2.8.2
     readerwriterlock>=1.0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     async-generator>=1.10
     async-property>=0.2.1
     cryptography>=3.4.0
-	httpcore<0.17.3
+    httpcore<0.17.3
     httpx[http2]==0.24.0
     python-dateutil>=2.8.2
     readerwriterlock>=1.0.9

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import socket
+from os import environ
+from time import time
 from types import TracebackType
 from typing import Any, Dict, List, Optional
 
@@ -231,9 +233,21 @@ async def connect(
 
     else:
         try:
+            timerStart = time()
             engine_url, status, attached_db = await _get_engine_url_status_db(
                 system_engine_connection, engine_name
             )
+
+            teimerEnd = time()
+            envVar = "0"
+            try:
+                envVar = environ["FIREBOLT_SDK_PERFORMANCE_DEBUG"]
+            except Exception:
+                pass
+
+            if envVar == "1":
+                totalTime = "{:.2f}".format(round((teimerEnd - timerStart), 2))
+                logger.debug(f"[PERFORMANCE] Resolving engine name {totalTime}s")
 
             if status != "Running":
                 raise EngineNotRunningError(engine_name)

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import socket
 from os import environ
-from time import time
 from types import TracebackType
 from typing import Any, Dict, List, Optional
 
@@ -31,7 +30,7 @@ from firebolt.utils.exception import (
     InterfaceError,
 )
 from firebolt.utils.usage_tracker import get_user_agent_header
-from firebolt.utils.util import fix_url_schema
+from firebolt.utils.util import Timer, fix_url_schema
 
 logger = logging.getLogger(__name__)
 
@@ -233,21 +232,14 @@ async def connect(
 
     else:
         try:
-            timerStart = time()
-            engine_url, status, attached_db = await _get_engine_url_status_db(
-                system_engine_connection, engine_name
-            )
+            with Timer() as runTime:
+                engine_url, status, attached_db = await _get_engine_url_status_db(
+                    system_engine_connection, engine_name
+                )
 
-            teimerEnd = time()
-            envVar = "0"
-            try:
-                envVar = environ["FIREBOLT_SDK_PERFORMANCE_DEBUG"]
-            except Exception:
-                pass
-
+            envVar = environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0")
             if envVar == "1":
-                totalTime = "{:.2f}".format(round((teimerEnd - timerStart), 2))
-                logger.debug(f"[PERFORMANCE] Resolving engine name {totalTime}s")
+                logger.debug(f"[PERFORMANCE] Resolving engine name {runTime}s")
 
             if status != "Running":
                 raise EngineNotRunningError(engine_name)

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import logging
 import socket
-from os import environ
 from types import TracebackType
 from typing import Any, Dict, List, Optional
 
@@ -31,8 +29,6 @@ from firebolt.utils.exception import (
 )
 from firebolt.utils.usage_tracker import get_user_agent_header
 from firebolt.utils.util import Timer, fix_url_schema
-
-logger = logging.getLogger(__name__)
 
 
 class OverriddenHttpBackend(AutoBackend):
@@ -232,14 +228,10 @@ async def connect(
 
     else:
         try:
-            with Timer() as runTime:
+            with Timer("[PERFORMANCE] Resolving engine name "):
                 engine_url, status, attached_db = await _get_engine_url_status_db(
                     system_engine_connection, engine_name
                 )
-
-            envVar = environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0")
-            if envVar == "1":
-                logger.debug(f"[PERFORMANCE] Resolving engine name {runTime}s")
 
             if status != "Running":
                 raise EngineNotRunningError(engine_name)

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -214,7 +214,9 @@ class Cursor(BaseCursor):
 
                     envVar = environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0")
                     if envVar == "1":
-                        logger.debug(f"[PERFORMANCE] Running query {query} {runTime}s")
+                        logger.debug(
+                            f"[PERFORMANCE] Running query {query[:50]} ... {runTime}s"
+                        )
 
                     await self._raise_if_error(response)
                     if response.headers.get("content-length", "") == "0":

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -4,7 +4,6 @@ import logging
 import re
 import time
 from functools import wraps
-from os import environ
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -202,7 +201,10 @@ class Cursor(BaseCursor):
                         async_execution,
                     )
 
-                    with Timer() as runTime:
+                    with Timer(
+                        f"[PERFORMANCE] Running query {query[:50]} "
+                        f"{'... ' if len(query) > 50 else ''}"
+                    ):
                         response = await self._api_request(
                             query,
                             {
@@ -210,12 +212,6 @@ class Cursor(BaseCursor):
                                 "advanced_mode": 1,
                                 "output_format": JSON_OUTPUT_FORMAT,
                             },
-                        )
-
-                    envVar = environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0")
-                    if envVar == "1":
-                        logger.debug(
-                            f"[PERFORMANCE] Running query {query[:50]} ... {runTime}s"
                         )
 
                     await self._raise_if_error(response)

--- a/src/firebolt/client/auth/base.py
+++ b/src/firebolt/client/auth/base.py
@@ -1,5 +1,3 @@
-from logging import getLogger
-from os import environ
 from time import time
 from typing import Generator, Optional
 
@@ -8,8 +6,6 @@ from httpx import Request, Response, codes
 
 from firebolt.utils.token_storage import TokenSecureStorage
 from firebolt.utils.util import Timer, cached_property
-
-logger = getLogger(__name__)
 
 
 class AuthRequest(Request):
@@ -111,7 +107,7 @@ class Auth(HttpxAuth):
         Yields:
             Request: Request required for auth flow
         """
-        with Timer() as runTime:
+        with Timer("[PERFORMANCE] Authentication "):
             if not self.token or self.expired:
                 yield from self.get_new_token_generator()
                 self._cache_token()
@@ -124,7 +120,3 @@ class Auth(HttpxAuth):
                 yield from self.get_new_token_generator()
                 request.headers["Authorization"] = f"Bearer {self.token}"
                 yield request
-
-        envVar = environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0")
-        if envVar == "1":
-            logger.debug(f"[PERFORMANCE] Authentication {runTime}s")

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -346,7 +346,9 @@ class BaseCursor:
             # We are out of elements
             return None
         assert self._rows is not None
-        return self._parse_row(self._rows[left])
+        with Timer("[PERFORMANCE] Parsing query output into native Python types "):
+            result = self._parse_row(self._rows[left])
+        return result
 
     @check_not_closed
     @check_query_executed
@@ -359,7 +361,9 @@ class BaseCursor:
         left, right = self._get_next_range(size)
         assert self._rows is not None
         rows = self._rows[left:right]
-        return [self._parse_row(row) for row in rows]
+        with Timer("[PERFORMANCE] Parsing query output into native Python types "):
+            result = [self._parse_row(row) for row in rows]
+        return result
 
     @check_not_closed
     @check_query_executed
@@ -368,10 +372,8 @@ class BaseCursor:
         left, right = self._get_next_range(self.rowcount)
         assert self._rows is not None
         rows = self._rows[left:right]
-
         with Timer("[PERFORMANCE] Parsing query output into native Python types "):
             result = [self._parse_row(row) for row in rows]
-
         return result
 
     @check_not_closed

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -4,7 +4,6 @@ import logging
 from dataclasses import dataclass, fields
 from enum import Enum
 from functools import wraps
-from os import environ
 from types import TracebackType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -370,14 +369,9 @@ class BaseCursor:
         assert self._rows is not None
         rows = self._rows[left:right]
 
-        with Timer() as tTime:
+        with Timer("[PERFORMANCE] Parsing query output into native Python types "):
             result = [self._parse_row(row) for row in rows]
 
-        envVar = environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0")
-        if envVar == "1":
-            logger.debug(
-                f"[PERFORMANCE] Parsing query output into native Python types {tTime}s"
-            )
         return result
 
     @check_not_closed

--- a/src/firebolt/utils/util.py
+++ b/src/firebolt/utils/util.py
@@ -1,4 +1,6 @@
+import logging
 from functools import lru_cache
+from os import environ
 from time import time
 from types import TracebackType
 from typing import TYPE_CHECKING, Callable, Type, TypeVar
@@ -6,6 +8,7 @@ from typing import TYPE_CHECKING, Callable, Type, TypeVar
 from httpx import URL
 
 T = TypeVar("T")
+logger = logging.getLogger(__name__)
 
 
 def cached_property(func: Callable[..., T]) -> T:
@@ -104,8 +107,11 @@ def merge_urls(base: URL, merge: URL) -> URL:
 
 
 class Timer:
+    def __init__(self, message: str = ""):
+        self._message = message
+
     def __enter__(self) -> "Timer":
-        self.start_time: float = time()
+        self._start_time: float = time()
         return self
 
     def __exit__(
@@ -114,4 +120,10 @@ class Timer:
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> None:
-        self.elapsed_time: str = "{:.2f}".format(round((time() - self.start_time), 2))
+        self.elapsed_time = "{:.2f}".format(round((time() - self._start_time), 2))
+        if (
+            environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0") == "1"
+            and self._message != ""
+        ):
+            log_message = self._message + self.elapsed_time + "s"
+            logger.debug(log_message)

--- a/src/firebolt/utils/util.py
+++ b/src/firebolt/utils/util.py
@@ -1,4 +1,6 @@
 from functools import lru_cache
+from time import time
+from types import TracebackType
 from typing import TYPE_CHECKING, Callable, Type, TypeVar
 
 from httpx import URL
@@ -99,3 +101,17 @@ def merge_urls(base: URL, merge: URL) -> URL:
         merge_raw_path = base.raw_path + merge.raw_path.lstrip(b"/")
         return base.copy_with(raw_path=merge_raw_path)
     return merge
+
+
+class Timer:
+    def __enter__(self) -> "Timer":
+        self.start_time: float = time()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> None:
+        self.elapsed_time: str = "{:.2f}".format(round((time() - self.start_time), 2))

--- a/src/firebolt/utils/util.py
+++ b/src/firebolt/utils/util.py
@@ -120,7 +120,7 @@ class Timer:
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> None:
-        self.elapsed_time = "{:.2f}".format(round((time() - self._start_time), 2))
+        self.elapsed_time: str = "{:.2f}".format(round((time() - self._start_time), 2))
         if (
             environ.get("FIREBOLT_SDK_PERFORMANCE_DEBUG", "0") == "1"
             and self._message != ""


### PR DESCRIPTION
added a timer option that counts the time of Authentication, Resolving engine name, Running query and Parsing query output. the info will be written on the log if an env variable named `FIREBOLT_SDK_PERFORMANCE_DEBUG` will be equal to 1