### PR TITLE
fix: remove dynamic/query path from system engine url

### DIFF
--- a/src/firebolt/async_db/util.py
+++ b/src/firebolt/async_db/util.py
@@ -12,7 +12,7 @@ from firebolt.utils.exception import (
     FireboltEngineError,
     InterfaceError,
 )
-from firebolt.utils.urls import DYNAMIC_QUERY, GATEWAY_HOST_BY_ACCOUNT_NAME
+from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
 
 if TYPE_CHECKING:
     from firebolt.async_db.connection import Connection
@@ -83,7 +83,7 @@ async def _get_system_engine_url(
                 f"Unable to retrieve system engine endpoint {url}: "
                 f"{response.status_code} {response.content}"
             )
-        return response.json()["engineUrl"] + DYNAMIC_QUERY
+        return response.json()["engineUrl"]
 
 
 async def _get_engine_url_status_db(

--- a/src/firebolt/db/util.py
+++ b/src/firebolt/db/util.py
@@ -12,7 +12,7 @@ from firebolt.utils.exception import (
     FireboltEngineError,
     InterfaceError,
 )
-from firebolt.utils.urls import DYNAMIC_QUERY, GATEWAY_HOST_BY_ACCOUNT_NAME
+from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
 
 if TYPE_CHECKING:
     from firebolt.db.connection import Connection
@@ -74,7 +74,6 @@ def _get_system_engine_url(
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS),
     ) as client:
-        #       return "https://api.us-east-1.dev.firebolt.io/dynamic"
         url = GATEWAY_HOST_BY_ACCOUNT_NAME.format(account_name=account_name)
         response = client.get(url=url)
         if response.status_code == codes.NOT_FOUND:
@@ -84,7 +83,7 @@ def _get_system_engine_url(
                 f"Unable to retrieve system engine endpoint {url}: "
                 f"{response.status_code} {response.content}"
             )
-        return response.json()["engineUrl"] + DYNAMIC_QUERY
+        return response.json()["engineUrl"]
 
 
 def _get_engine_url_status_db(

--- a/src/firebolt/utils/urls.py
+++ b/src/firebolt/utils/urls.py
@@ -28,4 +28,3 @@ PROVIDERS_URL = "/compute/v1/providers"
 REGIONS_URL = "/compute/v1/regions"
 
 GATEWAY_HOST_BY_ACCOUNT_NAME = "/web/v3/account/{account_name}/engineUrl"
-DYNAMIC_QUERY = "/dynamic/query"

--- a/tests/unit/db_conftest.py
+++ b/tests/unit/db_conftest.py
@@ -438,12 +438,12 @@ def system_engine_url() -> str:
 def system_engine_query_url(
     system_engine_url: str, db_name: str, account_id: str
 ) -> str:
-    return f"{system_engine_url}/dynamic/query?output_format=JSON_Compact&database={db_name}&account_id={account_id}"
+    return f"{system_engine_url}/?output_format=JSON_Compact&database={db_name}&account_id={account_id}"
 
 
 @fixture
 def system_engine_no_db_query_url(system_engine_url: str, account_id: str) -> str:
-    return f"{system_engine_url}/dynamic/query?output_format=JSON_Compact&account_id={account_id}"
+    return f"{system_engine_url}/?output_format=JSON_Compact&account_id={account_id}"
 
 
 @fixture


### PR DESCRIPTION
Removed `/dynamic/query` path from system engine url