### PR TITLE
ci: Make nightly-v0 action use v1 setup action

### DIFF
--- a/.github/workflows/nightly-v0.yml
+++ b/.github/workflows/nightly-v0.yml
@@ -8,4 +8,5 @@ jobs:
     uses: ./.github/workflows/nightly-workflow.yml
     with:
       branch: 0.x
+      setup-version: 'v1'
     secrets: inherit

--- a/.github/workflows/nightly-workflow.yml
+++ b/.github/workflows/nightly-workflow.yml
@@ -6,6 +6,11 @@ on:
         required: true
         type: string
         description: 'Branch to run on'
+      setup-version:
+        required: false
+        default: 'v2'
+        type: string
+        description: 'Version of setup action to use'
 jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml
@@ -55,7 +60,7 @@ jobs:
 
       - name: Setup database and engine
         id: setup
-        uses: firebolt-db/integration-testing-setup@v2
+        uses: firebolt-db/integration-testing-setup@${{ inputs.setup-version }}
         with:
           firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
           firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}


### PR DESCRIPTION
Nightly v0 action is currently broken because it uses setup action `v2` with credentials for `v1`. Made nightly v0 use `v1` setup action