### PR TITLE
fix: delete database when engines starting or stopping

### DIFF
--- a/src/firebolt/model/database.py
+++ b/src/firebolt/model/database.py
@@ -88,7 +88,7 @@ class Database(FireboltBaseModel):
         """
 
         for engine in self.get_attached_engines():
-            if engine.current_status not in {
+            if engine.current_status in {
                 EngineStatus.STARTING,
                 EngineStatus.STOPPING,
             }:


### PR DESCRIPTION
when deleting a database the check if the attached engines are starting or stopping was wrong