### PR TITLE
build: Limit anyio version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ project_urls =
 packages = find:
 install_requires =
     aiorwlock==1.1.0
+    anyio<4.0.0
     appdirs>=1.4.4
     appdirs-stubs>=0.1.0
     async-generator>=1.10


### PR DESCRIPTION
Anyio had a 4.0 release recently that affects internal API. We happen to use it in order to avoid a race condition. I'm limiting anyio to below 4.0 to avoid it. We can revisit the code affected, but at the moment I don't see an alternative API we can use.

This breaks on import when anyio 4.0 is installed: https://github.com/firebolt-db/firebolt-python-sdk/blob/0.x/src/firebolt/client/client.py#L3