### PR TITLE
fix: Engine service improvements

### DIFF
--- a/src/firebolt/model/engine.py
+++ b/src/firebolt/model/engine.py
@@ -213,7 +213,9 @@ class Engine(FireboltBaseModel):
         parameters are set to None, old engine parameter values remain.
         """
 
-        if not any((name, scale, spec, auto_stop, warmup, engine_type)):
+        if not any(
+            x is not None for x in (name, scale, spec, auto_stop, warmup, engine_type)
+        ):
             # Nothing to be updated
             return self
 
@@ -231,7 +233,7 @@ class Engine(FireboltBaseModel):
             self.ALTER_PARAMETER_NAMES,
             (scale, spec, auto_stop, name, warmup, engine_type),
         ):
-            if value:
+            if value is not None:
                 sql += f"{param} = ? "
                 parameters.append(str(value))
 

--- a/src/firebolt/service/engine.py
+++ b/src/firebolt/service/engine.py
@@ -156,13 +156,15 @@ class EngineService(BaseService):
             ("" if fail_if_exists else self.IF_NOT_EXISTS_SQL), name
         )
         parameters = []
-        if any((region, engine_type, spec, scale, auto_stop, warmup)):
+        if any(
+            x is not None for x in (region, engine_type, spec, scale, auto_stop, warmup)
+        ):
             sql += self.CREATE_WITH_SQL
             for param, value in zip(
                 self.CREATE_PARAMETER_NAMES,
                 (region, engine_type, spec, scale, auto_stop, warmup),
             ):
-                if value:
+                if value is not None:
                     sql += f"{param} = ? "
                     parameters.append(str(value))
         with self._connection.cursor() as c:

--- a/src/firebolt/service/types.py
+++ b/src/firebolt/service/types.py
@@ -47,6 +47,7 @@ class EngineStatus(Enum):
     STOPPED = "Stopped"
     DROPPING = "Dropping"
     REPAIRING = "Repairing"
+    FAILED = "Failed"
 
     def __str__(self) -> str:
         return self.value

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -308,11 +308,17 @@ def updated_engine_type() -> EngineType:
 
 
 @fixture
+def updated_auto_stop() -> EngineType:
+    return 0
+
+
+@fixture
 def update_engine_callback(
     system_engine_no_db_query_url: str,
     mock_engine: Engine,
     updated_engine_scale: int,
     updated_engine_type: EngineType,
+    updated_auto_stop: int,
 ) -> Callable:
     def do_mock(
         request: httpx.Request = None,
@@ -321,6 +327,7 @@ def update_engine_callback(
         assert request.url == system_engine_no_db_query_url
         mock_engine.scale = updated_engine_scale
         mock_engine.type = updated_engine_type
+        mock_engine.auto_stop = updated_auto_stop
         return Response(
             status_code=httpx.codes.OK,
             json=empty_response,

--- a/tests/unit/service/test_engine.py
+++ b/tests/unit/service/test_engine.py
@@ -149,3 +149,32 @@ def test_engine_update(
 
     assert mock_engine.scale == updated_engine_scale
     assert mock_engine.type == updated_engine_type
+
+    mock_engine.update(scale=updated_engine_scale, engine_type=updated_engine_type)
+
+    assert mock_engine.scale == updated_engine_scale
+    assert mock_engine.type == updated_engine_type
+
+
+def test_engine_update_auto_stop_zero(
+    httpx_mock: HTTPXMock,
+    resource_manager: ResourceManager,
+    instance_type_callback: Callable,
+    instance_type_url: str,
+    mock_engine: Engine,
+    get_engine_callback: Callable,
+    update_engine_callback: Callable,
+    system_engine_no_db_query_url: str,
+    updated_auto_stop: int,
+):
+    httpx_mock.add_callback(instance_type_callback, url=instance_type_url)
+    httpx_mock.add_callback(get_engine_callback, url=system_engine_no_db_query_url)
+    httpx_mock.add_callback(update_engine_callback, url=system_engine_no_db_query_url)
+    httpx_mock.add_callback(get_engine_callback, url=system_engine_no_db_query_url)
+
+    mock_engine.auto_stop = updated_auto_stop + 100
+    # auto_stop = 0 is not considered an empty parameter value
+    mock_engine._service = resource_manager.engines
+    mock_engine.update(auto_stop=0)
+
+    assert mock_engine.auto_stop == updated_auto_stop


### PR DESCRIPTION
Some minor resource manager updates for firebolt-cli
- Support passing auto_stop as 0 (don't treat it as empty parameter)
- Support for `Failed` engine state