### PR TITLE
feat: backward compatibility for get_by_name methods

### DIFF
--- a/src/firebolt/service/database.py
+++ b/src/firebolt/service/database.py
@@ -48,7 +48,7 @@ class DatabaseService(BaseService):
         return Database._from_dict(self._get_dict(name), self)
 
     def get_by_name(self, name: str) -> Database:
-        return Database._from_dict(self._get_dict(name), self)
+        return self.get(name)
 
     def get_many(
         self,

--- a/src/firebolt/service/database.py
+++ b/src/firebolt/service/database.py
@@ -47,6 +47,9 @@ class DatabaseService(BaseService):
         """Get a Database from Firebolt by its name."""
         return Database._from_dict(self._get_dict(name), self)
 
+    def get_by_name(self, name: str) -> Database:
+        return Database._from_dict(self._get_dict(name), self)
+
     def get_many(
         self,
         name_contains: Optional[str] = None,

--- a/src/firebolt/service/engine.py
+++ b/src/firebolt/service/engine.py
@@ -55,6 +55,9 @@ class EngineService(BaseService):
         """Get an engine from Firebolt by its name."""
         return Engine._from_dict(self._get_dict(name), self)
 
+    def get_by_name(self, name: str) -> Engine:
+        return self.get(name)
+
     def get_many(
         self,
         name_contains: Optional[str] = None,

--- a/tests/unit/service/test_database.py
+++ b/tests/unit/service/test_database.py
@@ -35,6 +35,22 @@ def test_database_create(
     assert database == mock_database
 
 
+def test_database_get_by_name(
+    httpx_mock: HTTPXMock,
+    resource_manager: ResourceManager,
+    database_get_callback: Callable,
+    system_engine_no_db_query_url: str,
+    mock_database: Database,
+):
+    httpx_mock.add_callback(
+        database_get_callback, url=system_engine_no_db_query_url, method="POST"
+    )
+
+    database = resource_manager.databases.get_by_name(mock_database.name)
+
+    assert database == mock_database
+
+
 def test_database_get(
     httpx_mock: HTTPXMock,
     resource_manager: ResourceManager,

--- a/tests/unit/service/test_engine.py
+++ b/tests/unit/service/test_engine.py
@@ -178,3 +178,20 @@ def test_engine_update_auto_stop_zero(
     mock_engine.update(auto_stop=0)
 
     assert mock_engine.auto_stop == updated_auto_stop
+
+
+def test_engine_get_by_name(
+    httpx_mock: HTTPXMock,
+    resource_manager: ResourceManager,
+    instance_type_callback: Callable,
+    instance_type_url: str,
+    get_engine_callback: Callable,
+    system_engine_no_db_query_url: str,
+    mock_engine: Engine,
+):
+    httpx_mock.add_callback(instance_type_callback, url=instance_type_url)
+    httpx_mock.add_callback(get_engine_callback, url=system_engine_no_db_query_url)
+
+    engine = resource_manager.engines.get_by_name(mock_engine.name)
+
+    assert engine == mock_engine


### PR DESCRIPTION
returned the `get_by_name` methods for database and engine in the new identity