### PR TITLE
build: Fix docs prerequisite

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 ./ # Install firebolt-sdk to ensure all code dependencies are also installed and avoid duplication
+sphinx-rtd-theme


### PR DESCRIPTION
Somehow readthedocs fails to pull the theme on main. Maybe it was once default but later was changed.
Regardless, it doesn't hurt to install it anyway.
Build succeeding now: https://readthedocs.com/projects/firebolt-firebolt-python-sdk-final/builds/1769046/