### PR TITLE
fix: Remove redundant lock

### DIFF
--- a/docsrc/Connecting_and_queries.rst
+++ b/docsrc/Connecting_and_queries.rst
@@ -386,6 +386,17 @@ In addition, server-side asynchronous queries can be cancelled calling ``cancel(
 **Returns**: ``CANCELED_EXECUTION``
 
 
+Thread safety
+==============================
+
+Thread safety is set to 2, meaning it's safe to share the module and
+:ref:`Connection <firebolt.db:Connection>` object across threads.
+:ref:`Cursor <firebolt.db:Cursor>` is a lightweight object that should be instantiated
+by calling ``connection.cursor()`` within a thread and should not be shared across different threads.
+Similarly, in an asynchronous context the Cursor obejct should not be shared across tasks
+as it will lead to a nondeterministic data returned. Follow the best practice from the
+:ref:`connecting_and_queries:Running multiple queries in parallel`.
+
 
 Using DATE and DATETIME values
 ==============================

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     python-dateutil>=2.8.2
     readerwriterlock>=1.0.9
     sqlparse>=0.4.2
-    tricycle>=0.2.2
     trio>=0.22.0
 python_requires = >=3.7
 include_package_data = True

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 from httpx import Response, codes
-from tricycle import RWLock
 
 from firebolt.async_db.util import is_db_available, is_engine_running
 from firebolt.common._types import (
@@ -98,8 +97,6 @@ class Cursor(BaseCursor):
 
     """
 
-    __slots__ = BaseCursor.__slots__ + ("_async_query_lock",)
-
     def __init__(
         self,
         *args: Any,
@@ -108,7 +105,6 @@ class Cursor(BaseCursor):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self._async_query_lock = RWLock()
         self._client = client
         self.connection = connection
 
@@ -438,26 +434,22 @@ class Cursor(BaseCursor):
 
     @wraps(BaseCursor.fetchone)
     async def fetchone(self) -> Optional[List[ColType]]:
-        async with self._async_query_lock.read_locked():
-            """Fetch the next row of a query result set."""
-            return super().fetchone()
+        """Fetch the next row of a query result set."""
+        return super().fetchone()
 
     @wraps(BaseCursor.fetchmany)
     async def fetchmany(self, size: Optional[int] = None) -> List[List[ColType]]:
-        async with self._async_query_lock.read_locked():
-            """
-            Fetch the next set of rows of a query result;
-            size is cursor.arraysize by default.
-            """
-            return super().fetchmany(size)
+        """
+        Fetch the next set of rows of a query result;
+        size is cursor.arraysize by default.
+        """
+        return super().fetchmany(size)
 
     @wraps(BaseCursor.fetchall)
     async def fetchall(self) -> List[List[ColType]]:
-        async with self._async_query_lock.read_locked():
-            """Fetch all remaining rows of a query result."""
-            return super().fetchall()
+        """Fetch all remaining rows of a query result."""
+        return super().fetchall()
 
     @wraps(BaseCursor.nextset)
     async def nextset(self) -> None:
-        async with self._async_query_lock.read_locked():
-            return super().nextset()
+        return super().nextset()

--- a/src/firebolt/client/auth/base.py
+++ b/src/firebolt/client/auth/base.py
@@ -1,9 +1,9 @@
 from time import time
 from typing import AsyncGenerator, Generator, Optional
 
+from anyio import Lock
 from httpx import Auth as HttpxAuth
 from httpx import Request, Response, codes
-from trio import Lock
 
 from firebolt.utils.token_storage import TokenSecureStorage
 from firebolt.utils.util import cached_property

--- a/tests/unit/async_db/test_connection.py
+++ b/tests/unit/async_db/test_connection.py
@@ -434,7 +434,7 @@ def test_from_asyncio(
     settings: Settings,
     db_name: str,
 ):
-    async def async_flow():
+    async def async_flow() -> None:
         async with (
             await connect(
                 engine_url=settings.server,
@@ -453,4 +453,4 @@ def test_from_asyncio(
 
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(query_callback, url=query_url)
-    run(async_flow)
+    run(async_flow())

--- a/tests/unit/client/test_client_async.py
+++ b/tests/unit/client/test_client_async.py
@@ -1,9 +1,11 @@
-from re import Pattern
-from typing import Callable
+from re import Pattern, compile
+from types import MethodType
+from typing import Any, Callable
 
-from httpx import codes
+from httpx import Request, Response, codes
 from pytest import raises
 from pytest_httpx import HTTPXMock
+from trio import open_nursery, sleep
 
 from firebolt.client import DEFAULT_API_URL, AsyncClient
 from firebolt.client.auth import Token, UsernamePassword
@@ -117,3 +119,49 @@ async def test_client_account_id(
         api_endpoint=settings.server,
     ) as c:
         assert await c.account_id == account_id, "Invalid account id returned."
+
+
+async def test_concurent_auth_lock(
+    httpx_mock: HTTPXMock,
+    server: str,
+    test_username: str,
+    test_password: str,
+    test_token: str,
+    auth_url: str,
+    check_token_callback: Callable,
+) -> None:
+    CONCURENT_COUNT = 10
+    url = "https://url"
+
+    checked_creds_times = 0
+
+    async def mock_send_handling_redirects(self, *args: Any, **kwargs: Any) -> Response:
+        # simulate network delay so the context switches
+        await sleep(0.01)
+        return await AsyncClient._send_handling_redirects(self, *args, **kwargs)
+
+    def check_credentials(
+        request: Request = None,
+        **kwargs,
+    ) -> Response:
+        nonlocal checked_creds_times
+        checked_creds_times += 1
+        return Response(
+            status_code=codes.OK,
+            json={"expires_in": 2**32, "access_token": test_token},
+        )
+
+    httpx_mock.add_callback(check_token_callback, url=compile(f"{url}/."))
+    httpx_mock.add_callback(check_credentials, url=auth_url)
+
+    async with AsyncClient(
+        auth=UsernamePassword(test_username, test_password),
+        api_endpoint=server,
+    ) as c:
+        c._send_handling_redirects = MethodType(mock_send_handling_redirects, c)
+        urls = [f"{url}/{i}" for i in range(CONCURENT_COUNT)]
+        async with open_nursery() as nursery:
+            for url in urls:
+                nursery.start_soon(c.get, url)
+
+    assert checked_creds_times == 1


### PR DESCRIPTION
Similar to the change in 1.x, removing trino lock as it affects runs from within asyncio.

Cherry picked from https://github.com/firebolt-db/firebolt-python-sdk/pull/303

UPD: this does not fix the asyncio runs. Added a test that shows this.