### PR TITLE
build: Fir 28002 relax httpx version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     async-property>=0.2.1
     cryptography>=3.4.0
     httpcore<0.17.3
-    httpx[http2]==0.24.0
+    httpx[http2]>=0.19.0
     pydantic[dotenv]>=1.8.2,<3.0.0
     python-dateutil>=2.8.2
     readerwriterlock>=1.0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     async-generator>=1.10
     async-property>=0.2.1
     cryptography>=3.4.0
-    httpcore<0.17.3
     httpx[http2]>=0.19.0
     pydantic[dotenv]>=1.8.2,<3.0.0
     python-dateutil>=2.8.2
@@ -56,7 +55,7 @@ dev =
     pyfakefs>=4.5.3
     pytest==7.2.0
     pytest-cov==3.0.0
-    pytest-httpx==0.22.0
+    pytest-httpx>=0.13.0
     pytest-mock==3.6.1
     pytest-timeout==2.1.0
     pytest-trio==0.8.0

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -11,7 +11,6 @@ from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import Auth
 from firebolt.client.client import AsyncClient, AsyncClientV1, AsyncClientV2
 from firebolt.common.base_connection import BaseConnection
-from firebolt.common.http_backend import AsyncKeepaliveTransport
 from firebolt.common.settings import DEFAULT_TIMEOUT_SECONDS
 from firebolt.utils.exception import (
     ConfigurationError,
@@ -212,7 +211,6 @@ async def connect_v2(
         base_url=system_engine_url,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=AsyncKeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
     # Don't use context manager since this will be stored
@@ -259,7 +257,6 @@ async def connect_v2(
                 base_url=engine_url,
                 api_endpoint=api_endpoint,
                 timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-                transport=AsyncKeepaliveTransport(),
                 headers={"User-Agent": user_agent_header},
             )
             return Connection(
@@ -300,7 +297,6 @@ async def connect_v1(
         account_name=account_name,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=AsyncKeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
 
@@ -330,7 +326,6 @@ async def connect_v1(
         base_url=engine_url,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=AsyncKeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
     return Connection(engine_url, database, client, CursorV1, None, api_endpoint)

--- a/src/firebolt/client/client.py
+++ b/src/firebolt/client/client.py
@@ -16,6 +16,10 @@ from firebolt.client.constants import (
     PROTOCOL_VERSION,
     PROTOCOL_VERSION_HEADER_NAME,
 )
+from firebolt.client.http_backend import (
+    AsyncKeepaliveTransport,
+    KeepaliveTransport,
+)
 from firebolt.utils.exception import (
     AccountNotFoundError,
     AccountNotFoundOrNoAccessError,
@@ -93,6 +97,9 @@ class FireboltClientMixin(FireboltClientMixinBase):
 
 
 class Client(FireboltClientMixin, HttpxClient, metaclass=ABCMeta):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs, transport=KeepaliveTransport())
+
     @cached_property
     @abstractmethod
     def account_id(self) -> str:
@@ -270,6 +277,9 @@ class ClientV1(Client):
 
 
 class AsyncClient(FireboltClientMixin, HttpxAsyncClient, metaclass=ABCMeta):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs, transport=AsyncKeepaliveTransport())
+
     @property
     @abstractmethod
     async def account_id(self) -> str:

--- a/src/firebolt/client/http_backend.py
+++ b/src/firebolt/client/http_backend.py
@@ -2,11 +2,11 @@ import socket
 from typing import Any
 
 try:
-    from httpcore.backends.auto import AutoBackend  # type: ignore [import]
-    from httpcore.backends.sync import SyncBackend  # type: ignore [import]
+    from httpcore.backends.auto import AutoBackend  # type: ignore
+    from httpcore.backends.sync import SyncBackend  # type: ignore
 except ImportError:
-    from httpcore._backends.auto import AutoBackend  # type: ignore [import]
-    from httpcore._backends.sync import SyncBackend  # type: ignore [import]
+    from httpcore._backends.auto import AutoBackend  # type: ignore
+    from httpcore._backends.sync import SyncBackend  # type: ignore
 
 from httpx import AsyncHTTPTransport, HTTPTransport
 

--- a/src/firebolt/common/http_backend.py
+++ b/src/firebolt/common/http_backend.py
@@ -1,0 +1,63 @@
+import socket
+from typing import Any, Optional
+
+try:
+    from httpcore.backends.auto import AutoBackend  # type: ignore [import]
+    from httpcore.backends.base import (  # type: ignore [import]
+        AsyncNetworkStream,
+    )
+except ImportError:
+    from httpcore._backends.auto import AutoBackend  # type: ignore [import]
+    from httpcore._backends.base import AsyncNetworkStream  # type: ignore [import]
+
+from httpx import AsyncHTTPTransport
+
+from firebolt.common.settings import KEEPALIVE_FLAG, KEEPIDLE_RATE
+
+
+class AsyncOverriddenHttpBackend(AutoBackend):
+    """
+    `OverriddenHttpBackend` is a short-term solution for the TCP
+    connection idle timeout issue described in the following article:
+    https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout
+    Since httpx creates a connection right before executing a request, the
+    backend must be overridden to set the socket to `KEEPALIVE`
+    and `KEEPIDLE` settings.
+    """
+
+    async def connect_tcp(  # type: ignore [override]
+        self,
+        host: str,
+        port: int,
+        timeout: Optional[float] = None,
+        local_address: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncNetworkStream:
+        stream = await super().connect_tcp(  # type: ignore [call-arg]
+            host,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            **kwargs,
+        )
+        # Enable keepalive
+        stream.get_extra_info("socket").setsockopt(
+            socket.SOL_SOCKET, socket.SO_KEEPALIVE, KEEPALIVE_FLAG
+        )
+        # MacOS does not have TCP_KEEPIDLE
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            keepidle = socket.TCP_KEEPIDLE
+        else:
+            keepidle = 0x10  # TCP_KEEPALIVE on mac
+
+        # Set keepalive to 60 seconds
+        stream.get_extra_info("socket").setsockopt(
+            socket.IPPROTO_TCP, keepidle, KEEPIDLE_RATE
+        )
+        return stream
+
+
+class AsyncKeepaliveTransport(AsyncHTTPTransport):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._pool._network_backend = AsyncOverriddenHttpBackend()

--- a/src/firebolt/common/http_backend.py
+++ b/src/firebolt/common/http_backend.py
@@ -1,18 +1,45 @@
 import socket
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 try:
     from httpcore.backends.auto import AutoBackend  # type: ignore [import]
     from httpcore.backends.base import (  # type: ignore [import]
         AsyncNetworkStream,
+        NetworkStream,
     )
+    from httpcore.backends.sync import SyncBackend  # type: ignore [import]
 except ImportError:
     from httpcore._backends.auto import AutoBackend  # type: ignore [import]
-    from httpcore._backends.base import AsyncNetworkStream  # type: ignore [import]
+    from httpcore._backends.base import (  # type: ignore [import]
+        AsyncNetworkStream,
+        NetworkStream,
+    )
+    from httpcore._backends.sync import SyncBackend  # type: ignore [import]
 
-from httpx import AsyncHTTPTransport
+from httpx import AsyncHTTPTransport, HTTPTransport
 
 from firebolt.common.settings import KEEPALIVE_FLAG, KEEPIDLE_RATE
+
+
+def override_stream(
+    stream: Union[NetworkStream, AsyncNetworkStream]
+) -> Union[NetworkStream, AsyncNetworkStream]:
+    # Enable keepalive
+    stream.get_extra_info("socket").setsockopt(
+        socket.SOL_SOCKET, socket.SO_KEEPALIVE, KEEPALIVE_FLAG
+    )
+    # MacOS does not have TCP_KEEPIDLE
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        keepidle = socket.TCP_KEEPIDLE
+    else:
+        keepidle = 0x10  # TCP_KEEPALIVE on mac
+
+    # Set keepalive to 60 seconds
+    stream.get_extra_info("socket").setsockopt(
+        socket.IPPROTO_TCP, keepidle, KEEPIDLE_RATE
+    )
+
+    return stream
 
 
 class AsyncOverriddenHttpBackend(AutoBackend):
@@ -40,24 +67,45 @@ class AsyncOverriddenHttpBackend(AutoBackend):
             local_address=local_address,
             **kwargs,
         )
-        # Enable keepalive
-        stream.get_extra_info("socket").setsockopt(
-            socket.SOL_SOCKET, socket.SO_KEEPALIVE, KEEPALIVE_FLAG
-        )
-        # MacOS does not have TCP_KEEPIDLE
-        if hasattr(socket, "TCP_KEEPIDLE"):
-            keepidle = socket.TCP_KEEPIDLE
-        else:
-            keepidle = 0x10  # TCP_KEEPALIVE on mac
 
-        # Set keepalive to 60 seconds
-        stream.get_extra_info("socket").setsockopt(
-            socket.IPPROTO_TCP, keepidle, KEEPIDLE_RATE
+        return override_stream(stream)
+
+
+class OverriddenHttpBackend(SyncBackend):
+    """
+    `OverriddenHttpBackend` is a short-term solution for the TCP
+    connection idle timeout issue described in the following article:
+    https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout
+    Since httpx creates a connection right before executing a request, the
+    backend must be overridden to set the socket to `KEEPALIVE`
+    and `KEEPIDLE` settings.
+    """
+
+    def connect_tcp(  # type: ignore [override]
+        self,
+        host: str,
+        port: int,
+        timeout: Optional[float] = None,
+        local_address: Optional[str] = None,
+        **kwargs: Any,
+    ) -> NetworkStream:
+        stream = super().connect_tcp(  # type: ignore [call-arg]
+            host,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            **kwargs,
         )
-        return stream
+        return override_stream(stream)
 
 
 class AsyncKeepaliveTransport(AsyncHTTPTransport):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._pool._network_backend = AsyncOverriddenHttpBackend()
+
+
+class KeepaliveTransport(HTTPTransport):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._pool._network_backend = OverriddenHttpBackend()

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -1,27 +1,17 @@
 from __future__ import annotations
 
 import logging
-import socket
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type
 from warnings import warn
 
-try:
-    from httpcore.backends.base import NetworkStream  # type: ignore [import]
-    from httpcore.backends.sync import SyncBackend  # type: ignore [import]
-except ImportError:
-    from httpcore._backends.base import NetworkStream  # type: ignore [import]
-    from httpcore._backends.sync import SyncBackend  # type: ignore [import]
-from httpx import HTTPTransport, Timeout
+from httpx import Timeout
 
 from firebolt.client import DEFAULT_API_URL, Client, ClientV1, ClientV2
 from firebolt.client.auth import Auth
 from firebolt.common.base_connection import BaseConnection
-from firebolt.common.settings import (
-    DEFAULT_TIMEOUT_SECONDS,
-    KEEPALIVE_FLAG,
-    KEEPIDLE_RATE,
-)
+from firebolt.common.http_backend import KeepaliveTransport
+from firebolt.common.settings import DEFAULT_TIMEOUT_SECONDS
 from firebolt.db.cursor import Cursor, CursorV1, CursorV2
 from firebolt.db.util import _get_system_engine_url
 from firebolt.utils.exception import (
@@ -34,48 +24,6 @@ from firebolt.utils.usage_tracker import get_user_agent_header
 from firebolt.utils.util import fix_url_schema, validate_engine_name_and_url_v1
 
 logger = logging.getLogger(__name__)
-
-
-class OverriddenHttpBackend(SyncBackend):
-    """
-    `OverriddenHttpBackend` is a short-term solution for the TCP
-    connection idle timeout issue described in the following article:
-    https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout
-    Since httpx creates a connection right before executing a request, the
-    backend must be overridden to set the socket to `KEEPALIVE`
-    and `KEEPIDLE` settings.
-    """
-
-    def connect_tcp(  # type: ignore [override]
-        self,
-        host: str,
-        port: int,
-        timeout: Optional[float] = None,
-        local_address: Optional[str] = None,
-        **kwargs: Any,
-    ) -> NetworkStream:
-        stream = super().connect_tcp(  # type: ignore [call-arg]
-            host,
-            port,
-            timeout=timeout,
-            local_address=local_address,
-            **kwargs,
-        )
-        # Enable keepalive
-        stream.get_extra_info("socket").setsockopt(
-            socket.SOL_SOCKET, socket.SO_KEEPALIVE, KEEPALIVE_FLAG
-        )
-        # MacOS does not have TCP_KEEPIDLE
-        if hasattr(socket, "TCP_KEEPIDLE"):
-            keepidle = socket.TCP_KEEPIDLE
-        else:
-            keepidle = 0x10  # TCP_KEEPALIVE on mac
-
-        # Set keepalive to 60 seconds
-        stream.get_extra_info("socket").setsockopt(
-            socket.IPPROTO_TCP, keepidle, KEEPIDLE_RATE
-        )
-        return stream
 
 
 def connect(
@@ -163,15 +111,13 @@ def connect_v2(
         _get_system_engine_url(auth, account_name, api_endpoint)
     )
 
-    transport = HTTPTransport()
-    transport._pool._network_backend = OverriddenHttpBackend()
     client = ClientV2(
         auth=auth,
         account_name=account_name,
         base_url=system_engine_url,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=transport,
+        transport=KeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
     # Don't use context manager since this will be stored
@@ -217,7 +163,7 @@ def connect_v2(
                 base_url=engine_url,
                 api_endpoint=api_endpoint,
                 timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-                transport=transport,
+                transport=KeepaliveTransport(),
                 headers={"User-Agent": user_agent_header},
             )
             return Connection(
@@ -280,8 +226,6 @@ class Connection(BaseConnection):
         self._cursors: List[Cursor] = []
         self._system_engine_connection = system_engine_connection
         # Override tcp keepalive settings for connection
-        transport = HTTPTransport()
-        transport._pool._network_backend = OverriddenHttpBackend()
         self._client = client
         super().__init__()
 
@@ -351,15 +295,13 @@ def connect_v1(
     api_endpoint = fix_url_schema(api_endpoint)
 
     # Override tcp keepalive settings for connection
-    transport = HTTPTransport()
-    transport._pool._network_backend = OverriddenHttpBackend()
     no_engine_client = ClientV1(
         auth=auth,
         base_url=api_endpoint,
         account_name=account_name,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=transport,
+        transport=KeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
 
@@ -389,7 +331,7 @@ def connect_v1(
         base_url=engine_url,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=transport,
+        transport=KeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
     return Connection(engine_url, database, client, CursorV1, None, api_endpoint)

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -10,7 +10,6 @@ from httpx import Timeout
 from firebolt.client import DEFAULT_API_URL, Client, ClientV1, ClientV2
 from firebolt.client.auth import Auth
 from firebolt.common.base_connection import BaseConnection
-from firebolt.common.http_backend import KeepaliveTransport
 from firebolt.common.settings import DEFAULT_TIMEOUT_SECONDS
 from firebolt.db.cursor import Cursor, CursorV1, CursorV2
 from firebolt.db.util import _get_system_engine_url
@@ -117,7 +116,6 @@ def connect_v2(
         base_url=system_engine_url,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=KeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
     # Don't use context manager since this will be stored
@@ -163,7 +161,6 @@ def connect_v2(
                 base_url=engine_url,
                 api_endpoint=api_endpoint,
                 timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-                transport=KeepaliveTransport(),
                 headers={"User-Agent": user_agent_header},
             )
             return Connection(
@@ -301,7 +298,6 @@ def connect_v1(
         account_name=account_name,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=KeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
 
@@ -331,7 +327,6 @@ def connect_v1(
         base_url=engine_url,
         api_endpoint=api_endpoint,
         timeout=Timeout(DEFAULT_TIMEOUT_SECONDS, read=None),
-        transport=KeepaliveTransport(),
         headers={"User-Agent": user_agent_header},
     )
     return Connection(engine_url, database, client, CursorV1, None, api_endpoint)

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -6,8 +6,12 @@ from types import TracebackType
 from typing import Any, Dict, List, Optional, Type
 from warnings import warn
 
-from httpcore.backends.base import NetworkStream
-from httpcore.backends.sync import SyncBackend
+try:
+    from httpcore.backends.base import NetworkStream  # type: ignore [import]
+    from httpcore.backends.sync import SyncBackend  # type: ignore [import]
+except ImportError:
+    from httpcore._backends.base import NetworkStream  # type: ignore [import]
+    from httpcore._backends.sync import SyncBackend  # type: ignore [import]
 from httpx import HTTPTransport, Timeout
 
 from firebolt.client import DEFAULT_API_URL, Client, ClientV1, ClientV2

--- a/tests/integration/dbapi/async/V1/test_queries_async.py
+++ b/tests/integration/dbapi/async/V1/test_queries_async.py
@@ -169,7 +169,6 @@ async def test_select(
         )
 
 
-@mark.skip(reason="V1 query doesn't finish within the timeout")
 @mark.slow
 @mark.timeout(timeout=600)
 async def test_long_query(

--- a/tests/integration/dbapi/sync/V1/test_queries.py
+++ b/tests/integration/dbapi/sync/V1/test_queries.py
@@ -120,7 +120,6 @@ def test_select(
         )
 
 
-@mark.skip(reason="V1 query doesn't finish within the timeout")
 @mark.slow
 @mark.timeout(timeout=600)
 def test_long_query(

--- a/tests/unit/client/V1/conftest.py
+++ b/tests/unit/client/V1/conftest.py
@@ -3,11 +3,12 @@ import typing
 from re import Pattern, compile
 
 import httpx
-from httpx import Request, Response
+from httpx import Request
 from pytest import fixture
 
 from firebolt.utils.exception import AccountNotFoundError
 from firebolt.utils.urls import ACCOUNT_BY_NAME_URL, ACCOUNT_URL, AUTH_URL
+from tests.unit.response import Response
 
 
 @fixture

--- a/tests/unit/client/V1/test_client_async.py
+++ b/tests/unit/client/V1/test_client_async.py
@@ -2,7 +2,7 @@ from re import Pattern, compile
 from types import MethodType
 from typing import Any, Callable
 
-from httpx import Request, Response, codes
+from httpx import Request, codes
 from pytest import raises
 from pytest_httpx import HTTPXMock
 from trio import open_nursery, sleep
@@ -12,6 +12,7 @@ from firebolt.client import AsyncClientV1 as AsyncClient
 from firebolt.client.auth import Token, UsernamePassword
 from firebolt.utils.urls import AUTH_URL
 from firebolt.utils.util import fix_url_schema
+from tests.unit.conftest import Response
 
 
 async def test_client_retry(

--- a/tests/unit/client/V2/test_client_async.py
+++ b/tests/unit/client/V2/test_client_async.py
@@ -2,7 +2,7 @@ from re import Pattern, compile
 from types import MethodType
 from typing import Any, Callable
 
-from httpx import Request, Response, codes
+from httpx import Request, codes
 from pytest import raises
 from pytest_httpx import HTTPXMock
 from trio import open_nursery, sleep
@@ -11,6 +11,7 @@ from firebolt.client import AsyncClientV2 as AsyncClient
 from firebolt.client.auth import Auth, ClientCredentials
 from firebolt.utils.urls import AUTH_SERVICE_ACCOUNT_URL
 from firebolt.utils.util import fix_url_schema
+from tests.unit.conftest import Response
 
 
 async def test_client_retry(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ from re import Pattern, compile
 from typing import Callable
 
 import httpx
-from httpx import Request, Response
+from httpx import Request
 from pyfakefs.fake_filesystem_unittest import Patcher
 from pytest import fixture
 
@@ -31,6 +31,7 @@ from firebolt.utils.urls import (
     ENGINES_URL,
 )
 from tests.unit.db_conftest import *  # noqa
+from tests.unit.response import Response
 
 
 # Register nofakefs mark

--- a/tests/unit/db/V1/conftest.py
+++ b/tests/unit/db/V1/conftest.py
@@ -3,7 +3,7 @@ from re import Pattern, compile
 from typing import Callable
 
 import httpx
-from httpx import Request, Response, codes
+from httpx import Request, codes
 from pytest import fixture
 
 from firebolt.client import ClientV1 as Client
@@ -17,6 +17,7 @@ from firebolt.utils.urls import (
     ACCOUNT_URL,
     AUTH_URL,
 )
+from tests.unit.response import Response
 
 
 @fixture

--- a/tests/unit/db/V2/test_cursor.py
+++ b/tests/unit/db/V2/test_cursor.py
@@ -18,6 +18,7 @@ from firebolt.utils.exception import (
     QueryNotRunError,
 )
 from tests.unit.db_conftest import encode_param
+from tests.unit.response import Response
 
 
 def test_cursor_state(
@@ -219,7 +220,12 @@ def test_cursor_execute_error(
         ), f"Invalid query error message for {message}."
 
         # HTTP error
-        httpx_mock.add_response(status_code=codes.BAD_REQUEST, url=query_url)
+        httpx_mock.add_callback(
+            lambda *args, **kwargs: Response(
+                status_code=codes.BAD_REQUEST,
+            ),
+            url=query_url,
+        )
         with raises(HTTPStatusError) as excinfo:
             query()
 
@@ -228,9 +234,11 @@ def test_cursor_execute_error(
         assert "Bad Request" in errmsg, f"Invalid query error message for {message}."
 
         # Database query error
-        httpx_mock.add_response(
-            status_code=codes.INTERNAL_SERVER_ERROR,
-            content="Query error message",
+        httpx_mock.add_callback(
+            lambda *args, **kwargs: Response(
+                status_code=codes.INTERNAL_SERVER_ERROR,
+                content="Query error message",
+            ),
             url=query_url,
         )
         with raises(OperationalError) as excinfo:
@@ -242,9 +250,11 @@ def test_cursor_execute_error(
         ), f"Invalid authentication error message for {message}."
 
         # Database does not exist error
-        httpx_mock.add_response(
-            status_code=codes.FORBIDDEN,
-            content="Query error message",
+        httpx_mock.add_callback(
+            lambda *args, **kwargs: Response(
+                status_code=codes.FORBIDDEN,
+                content="Query error message",
+            ),
             url=query_url,
         )
         httpx_mock.add_response(
@@ -264,9 +274,11 @@ def test_cursor_execute_error(
 
         # Database exists but some other error
         error_message = "My query error message"
-        httpx_mock.add_response(
-            status_code=codes.FORBIDDEN,
-            content=error_message,
+        httpx_mock.add_callback(
+            lambda *args, **kwargs: Response(
+                status_code=codes.FORBIDDEN,
+                content=error_message,
+            ),
             url=query_url,
             match_content=b"select * from t",
         )
@@ -286,9 +298,11 @@ def test_cursor_execute_error(
         assert error_message in str(excinfo)
 
         # Engine is not running error
-        httpx_mock.add_response(
-            status_code=codes.SERVICE_UNAVAILABLE,
-            content="Query error message",
+        httpx_mock.add_callback(
+            lambda *args, **kwargs: Response(
+                status_code=codes.SERVICE_UNAVAILABLE,
+                content="Query error message",
+            ),
             url=query_url,
         )
         httpx_mock.add_response(
@@ -311,9 +325,11 @@ def test_cursor_execute_error(
         assert server in str(excinfo)
 
         # Engine does not exist
-        httpx_mock.add_response(
-            status_code=codes.SERVICE_UNAVAILABLE,
-            content="Query error message",
+        httpx_mock.add_callback(
+            lambda *args, **kwargs: Response(
+                status_code=codes.SERVICE_UNAVAILABLE,
+                content="Query error message",
+            ),
             url=query_url,
         )
         httpx_mock.add_response(

--- a/tests/unit/db_conftest.py
+++ b/tests/unit/db_conftest.py
@@ -3,13 +3,14 @@ from decimal import Decimal
 from json import dumps as jdumps
 from typing import Any, Callable, Dict, List
 
-from httpx import URL, Request, Response, codes
+from httpx import URL, Request, codes
 from pytest import fixture
 from pytest_httpx import HTTPXMock
 
 from firebolt.async_db.cursor import JSON_OUTPUT_FORMAT, ColType, Column
 from firebolt.db import ARRAY, DECIMAL
 from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
+from tests.unit.response import Response
 
 QUERY_ROW_COUNT: int = 10
 

--- a/tests/unit/response.py
+++ b/tests/unit/response.py
@@ -10,4 +10,4 @@ try:
         return to_response(*args, **kwargs)
 
 except ImportError:
-    pass
+    from httpx import Response  # noqa: F401

--- a/tests/unit/response.py
+++ b/tests/unit/response.py
@@ -1,0 +1,13 @@
+try:
+    # older version of pytest-httpx have their own Response class
+    from pytest_httpx import to_response
+
+    def Response(*args, **kwargs):
+        # Allow passing data as content
+        kwargs["data"] = kwargs.get("data", kwargs.get("content"))
+        if "content" in kwargs:
+            del kwargs["content"]
+        return to_response(*args, **kwargs)
+
+except ImportError:
+    pass

--- a/tests/unit/service/V1/conftest.py
+++ b/tests/unit/service/V1/conftest.py
@@ -4,7 +4,7 @@ from typing import Callable, List
 from urllib.parse import urlparse
 
 import httpx
-from httpx import Request, Response
+from httpx import Request
 from pytest import fixture
 
 from firebolt.client.auth.base import Auth
@@ -30,6 +30,7 @@ from firebolt.utils.urls import (
     PROVIDERS_URL,
     REGIONS_URL,
 )
+from tests.unit.response import Response
 from tests.unit.util import (
     list_to_paginated_response_v1 as list_to_paginated_response,
 )

--- a/tests/unit/service/V2/conftest.py
+++ b/tests/unit/service/V2/conftest.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Callable, List
 
 import httpx
-from httpx import Response
 from pytest import fixture
 
 from firebolt.client.auth import Auth
@@ -14,6 +13,7 @@ from firebolt.model.V2.instance_type import InstanceType
 from firebolt.service.manager import ResourceManager
 from firebolt.service.V2.types import EngineStatus, EngineType, WarmupMethod
 from firebolt.utils.urls import ACCOUNT_INSTANCE_TYPES_URL
+from tests.unit.response import Response
 from tests.unit.util import list_to_paginated_response
 
 


### PR DESCRIPTION
- Relaxed `httpx` minimal version to 0.19. 
- Relased `pytest-httpx` minimal version to 0.13 (corresponds to `httpx==0.19`)
- Update unit test mocks to support a range of pytest-httpx version