### PR TITLE
fix: Refresh auth token on 500

### DIFF
--- a/src/firebolt/client/auth/base.py
+++ b/src/firebolt/client/auth/base.py
@@ -7,7 +7,7 @@ from httpx import Auth as HttpxAuth
 from httpx import Request, Response, codes
 
 from firebolt.utils.token_storage import TokenSecureStorage
-from firebolt.utils.util import Timer, cached_property
+from firebolt.utils.util import Timer, cached_property, get_internal_error_code
 
 
 class AuthRequest(Request):
@@ -128,7 +128,10 @@ class Auth(HttpxAuth):
 
             response = yield request
 
-            if response.status_code == codes.UNAUTHORIZED:
+            if (
+                response.status_code == codes.UNAUTHORIZED
+                or get_internal_error_code(response) == codes.UNAUTHORIZED
+            ):
                 yield from self.get_new_token_generator()
                 request.headers["Authorization"] = f"Bearer {self.token}"
                 yield request

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import Response
+from httpx import Response, codes
 
 from firebolt.utils.util import get_internal_error_code
 
@@ -7,16 +7,20 @@ from firebolt.utils.util import get_internal_error_code
 @pytest.mark.parametrize(
     "status_code, content, expected_error_code",
     [
-        (200, b"No error code here", None),
-        (500, b"No error code here", None),
+        (codes.OK, b"No error code here", None),
+        (codes.INTERNAL_SERVER_ERROR, b"No error code here", None),
         (
-            500,
+            codes.INTERNAL_SERVER_ERROR,
             b"HTTP status code: 401 Unauthorized, body: failed to verify JWT token",
-            401,
+            codes.UNAUTHORIZED,
         ),
-        (500, b"HTTP status code: 401 Unauthorized", 401),
         (
-            500,
+            codes.INTERNAL_SERVER_ERROR,
+            b"HTTP status code: 401 Unauthorized",
+            codes.UNAUTHORIZED,
+        ),
+        (
+            codes.INTERNAL_SERVER_ERROR,
             b"HTTP status code: Unauthorized, body: failed to verify JWT token",
             None,
         ),

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,0 +1,27 @@
+import pytest
+from httpx import Response
+
+from firebolt.utils.util import get_internal_error_code
+
+
+@pytest.mark.parametrize(
+    "status_code, content, expected_error_code",
+    [
+        (200, b"No error code here", None),
+        (500, b"No error code here", None),
+        (
+            500,
+            b"HTTP status code: 401 Unauthorized, body: failed to verify JWT token",
+            401,
+        ),
+        (500, b"HTTP status code: 401 Unauthorized", 401),
+        (
+            500,
+            b"HTTP status code: Unauthorized, body: failed to verify JWT token",
+            None,
+        ),
+    ],
+)
+def test_get_internal_error_code(status_code, content, expected_error_code):
+    response = Response(status_code=status_code, content=content)
+    assert get_internal_error_code(response) == expected_error_code


### PR DESCRIPTION
Adding a fix described in FIR-29334

Server does not propagate the error even if token expires. This leads to us not refreshing the token when we should have been able to. Until there's a fix on the backend (might take considerable time) we have to try to check in the error body.