### PR TITLE
tests: reduce query size for v1 long test

### DIFF
--- a/tests/integration/dbapi/async/V1/test_queries_async.py
+++ b/tests/integration/dbapi/async/V1/test_queries_async.py
@@ -177,7 +177,7 @@ async def test_long_query(
     """AWS ALB TCP timeout set to 350; make sure we handle the keepalive correctly."""
     with connection.cursor() as c:
         await c.execute(
-            "SELECT checksum(*) FROM GENERATE_SERIES(1, 200000000000)",  # approx 6m runtime
+            "SELECT checksum(*) FROM GENERATE_SERIES(1, 150000000000)",  # approx 6m runtime
         )
         data = await c.fetchall()
         assert len(data) == 1, "Invalid data size returned by fetchall"

--- a/tests/integration/dbapi/sync/V1/test_queries.py
+++ b/tests/integration/dbapi/sync/V1/test_queries.py
@@ -128,7 +128,7 @@ def test_long_query(
     """AWS ALB TCP timeout set to 350, make sure we handle the keepalive correctly."""
     with connection.cursor() as c:
         c.execute(
-            "SELECT checksum(*) FROM GENERATE_SERIES(1, 200000000000)",  # approx 6m runtime
+            "SELECT checksum(*) FROM GENERATE_SERIES(1, 150000000000)",  # approx 6m runtime
         )
         data = c.fetchall()
         assert len(data) == 1, "Invalid data size returned by fetchall"


### PR DESCRIPTION
Reduced the query computation time for a long v1 test