### PR TITLE
test: removed join index queries

### DIFF
--- a/tests/integration/dbapi/async/V1/test_queries_async.py
+++ b/tests/integration/dbapi/async/V1/test_queries_async.py
@@ -200,7 +200,6 @@ async def test_drop_create(connection: Connection) -> None:
     """Create table query is handled properly"""
     with connection.cursor() as c:
         # Cleanup
-        await c.execute("DROP JOIN INDEX IF EXISTS test_drop_create_async_db_join_idx")
         await c.execute(
             "DROP AGGREGATING INDEX IF EXISTS test_drop_create_async_db_agg_idx"
         )
@@ -221,22 +220,12 @@ async def test_drop_create(connection: Connection) -> None:
             ", f float, d date, dt datetime, b bool, a array(int))",
         )
 
-        # Create join index
-        await test_query(
-            c,
-            "CREATE JOIN INDEX test_db_join_idx ON "
-            "test_drop_create_async_dim(id, sn, f)",
-        )
-
         # Create aggregating index
         await test_query(
             c,
             "CREATE AGGREGATING INDEX test_db_agg_idx ON "
             "test_drop_create_async(id, sum(f), count(dt))",
         )
-
-        # Drop join index
-        await test_query(c, "DROP JOIN INDEX test_db_join_idx")
 
         # Drop aggregating index
         await test_query(c, "DROP AGGREGATING INDEX test_db_agg_idx")

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -129,7 +129,6 @@ async def test_drop_create(connection: Connection) -> None:
     """Create table query is handled properly"""
     with connection.cursor() as c:
         # Cleanup
-        await c.execute("DROP JOIN INDEX IF EXISTS test_db_join_idx")
         await c.execute("DROP AGGREGATING INDEX IF EXISTS test_db_agg_idx")
         await c.execute("DROP TABLE IF EXISTS test_drop_create_async")
         await c.execute("DROP TABLE IF EXISTS test_drop_create_async_dim")
@@ -148,22 +147,12 @@ async def test_drop_create(connection: Connection) -> None:
             ", f float, d date, dt datetime, b bool, a array(int))",
         )
 
-        # Create join index
-        await test_query(
-            c,
-            "CREATE JOIN INDEX test_db_join_idx ON "
-            "test_drop_create_async_dim(id, sn, f)",
-        )
-
         # Create aggregating index
         await test_query(
             c,
             "CREATE AGGREGATING INDEX test_db_agg_idx ON "
             "test_drop_create_async(id, sum(f), count(dt))",
         )
-
-        # Drop join index
-        await test_query(c, "DROP JOIN INDEX test_db_join_idx")
 
         # Drop aggregating index
         await test_query(c, "DROP AGGREGATING INDEX test_db_agg_idx")

--- a/tests/integration/dbapi/sync/V1/test_queries.py
+++ b/tests/integration/dbapi/sync/V1/test_queries.py
@@ -150,7 +150,6 @@ def test_drop_create(connection: Connection) -> None:
     """Create table query is handled properly"""
     with connection.cursor() as c:
         # Cleanup
-        c.execute("DROP JOIN INDEX IF EXISTS test_drop_create_db_join_idx")
         c.execute("DROP AGGREGATING INDEX IF EXISTS test_drop_create_db_agg_idx")
         c.execute("DROP TABLE IF EXISTS test_drop_create_tb")
         c.execute("DROP TABLE IF EXISTS test_drop_create_tb_dim")
@@ -169,22 +168,12 @@ def test_drop_create(connection: Connection) -> None:
             ", f float, d date, dt datetime, b bool, a array(int))",
         )
 
-        # Create join index
-        test_query(
-            c,
-            "CREATE JOIN INDEX test_drop_create_db_join_idx ON "
-            "test_drop_create_tb_dim(id, sn, f)",
-        )
-
         # Create aggregating index
         test_query(
             c,
             "CREATE AGGREGATING INDEX test_drop_create_db_agg_idx ON "
             "test_drop_create_tb(id, sum(f), count(dt))",
         )
-
-        # Drop join index
-        test_query(c, "DROP JOIN INDEX test_drop_create_db_join_idx")
 
         # Drop aggregating index
         test_query(c, "DROP AGGREGATING INDEX test_drop_create_db_agg_idx")

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -135,7 +135,6 @@ def test_drop_create(connection: Connection) -> None:
     """Create table query is handled properly"""
     with connection.cursor() as c:
         # Cleanup
-        c.execute("DROP JOIN INDEX IF EXISTS test_drop_create_db_join_idx")
         c.execute("DROP AGGREGATING INDEX IF EXISTS test_drop_create_db_agg_idx")
         c.execute("DROP TABLE IF EXISTS test_drop_create_tb")
         c.execute("DROP TABLE IF EXISTS test_drop_create_tb_dim")
@@ -154,22 +153,12 @@ def test_drop_create(connection: Connection) -> None:
             ", f float, d date, dt datetime, b bool, a array(int))",
         )
 
-        # Create join index
-        test_query(
-            c,
-            "CREATE JOIN INDEX test_drop_create_db_join_idx ON "
-            "test_drop_create_tb_dim(id, sn, f)",
-        )
-
         # Create aggregating index
         test_query(
             c,
             "CREATE AGGREGATING INDEX test_drop_create_db_agg_idx ON "
             "test_drop_create_tb(id, sum(f), count(dt))",
         )
-
-        # Drop join index
-        test_query(c, "DROP JOIN INDEX test_drop_create_db_join_idx")
 
         # Drop aggregating index
         test_query(c, "DROP AGGREGATING INDEX test_drop_create_db_agg_idx")


### PR DESCRIPTION
Removed `CREATE/DELETE JOIN INDEX` queries from integration tests since they're deprecated now