### PR TITLE
feat: Use engine support

### DIFF
--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -6,15 +6,15 @@ from typing import Any, Dict, List, Optional, Type
 from httpx import Timeout
 
 from firebolt.async_db.cursor import Cursor, CursorV1, CursorV2
-from firebolt.async_db.util import (
-    ENGINE_STATUS_RUNNING_LIST,
-    _get_system_engine_url,
-)
+from firebolt.async_db.util import _get_system_engine_url
 from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import Auth
 from firebolt.client.client import AsyncClient, AsyncClientV1, AsyncClientV2
 from firebolt.common.base_connection import BaseConnection
-from firebolt.common.constants import DEFAULT_TIMEOUT_SECONDS
+from firebolt.common.constants import (
+    DEFAULT_TIMEOUT_SECONDS,
+    ENGINE_STATUS_RUNNING_LIST,
+)
 from firebolt.utils.exception import (
     ConfigurationError,
     ConnectionClosedError,

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -142,8 +142,8 @@ async def connect(
     user_agent_header = get_user_agent_header(user_drivers, user_clients)
     # Use v2 if auth is ClientCredentials
     # Use v1 if auth is ServiceAccount or UsernamePassword
-    version = auth.get_firebolt_version()
-    if version == 2:
+    auth_version = auth.get_firebolt_version()
+    if auth_version == 2:
         assert account_name is not None
         return await connect_v2(
             auth=auth,
@@ -153,7 +153,7 @@ async def connect(
             engine_name=engine_name,
             api_endpoint=api_endpoint,
         )
-    elif version == 1:
+    elif auth_version == 1:
         return await connect_v1(
             auth=auth,
             user_agent_header=user_agent_header,

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, List, Optional, Type
 from httpx import Timeout
 
 from firebolt.async_db.cursor import Cursor, CursorV1, CursorV2
-from firebolt.async_db.util import _get_system_engine_url
+from firebolt.async_db.util import (
+    ENGINE_STATUS_RUNNING_LIST,
+    _get_system_engine_url,
+)
 from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import Auth
 from firebolt.client.client import AsyncClient, AsyncClientV1, AsyncClientV2
@@ -226,7 +229,8 @@ async def connect_v2(
         api_endpoint,
     )
 
-    if system_engine_connection._client._account_version == 2:
+    account_version = await system_engine_connection._client._account_version
+    if account_version == 2:
         cursor = system_engine_connection.cursor()
         if database:
             await cursor.execute(f"USE DATABASE {database}")
@@ -258,7 +262,7 @@ async def connect_v2(
                     attached_db,
                 ) = await cursor._get_engine_url_status_db(engine_name)
 
-            if status != "Running":
+            if status not in ENGINE_STATUS_RUNNING_LIST:
                 raise EngineNotRunningError(engine_name)
 
             if database is not None and database != attached_db:

--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -245,7 +245,7 @@ async def connect_v2(
             CursorV2,
             system_engine_connection,
             api_endpoint,
-            cursor._set_parameters,
+            cursor.parameters,
         )
 
     if not engine_name:

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -517,7 +517,6 @@ class CursorV2(Cursor):
             # System engine is always running
             return True
 
-        engine_name = self.get_engine_name(engine_url)
         assert self.connection._system_engine_connection is not None  # Type check
         system_cursor = self.connection._system_engine_connection.cursor()
         assert isinstance(system_cursor, CursorV2)  # Type check, should always be true
@@ -525,7 +524,7 @@ class CursorV2(Cursor):
             _,
             status,
             _,
-        ) = await system_cursor._get_engine_url_status_db(engine_name)
+        ) = await system_cursor._get_engine_url_status_db(self.engine_name)
         return status in ENGINE_STATUS_RUNNING_LIST
 
     async def _get_engine_url_status_db(self, engine_name: str) -> Tuple[str, str, str]:

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -90,7 +90,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         if connection.database:
             self.database = connection.database
         if connection.init_parameters:
-            self._set_parameters = connection.init_parameters.copy()
+            self._update_set_parameters(connection.init_parameters)
 
     @abstractmethod
     async def _api_request(

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -20,7 +20,7 @@ from typing import (
 from httpx import URL, Headers, Response, codes
 
 from firebolt.async_db.util import ENGINE_STATUS_RUNNING
-from firebolt.client.client import AsyncClientV1, AsyncClientV2
+from firebolt.client.client import AsyncClient, AsyncClientV1, AsyncClientV2
 from firebolt.common._types import (
     ColType,
     Column,
@@ -79,11 +79,12 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
     def __init__(
         self,
         *args: Any,
+        client: AsyncClient,
         connection: Connection,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        assert isinstance(self._client, (AsyncClientV1, AsyncClientV2))
+        self._client = client
         self.connection = connection
         self.engine_url = connection.engine_url
         if connection.database:
@@ -161,7 +162,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
                 )
             self._update_set_parameters(params)
             self.engine_url = endpoint
-            self._client.base_url = endpoint
+            self._client.base_url = URL(endpoint)
 
         if headers.get(RESET_SESSION_HEADER):
             self.flush_parameters()

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -163,7 +163,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
 
         if headers.get(UPDATE_PARAMETERS_HEADER):
             param_dict = _parse_update_parameters(headers.get(UPDATE_PARAMETERS_HEADER))
-            self._update_server_parameters(param_dict)
+            self._update_set_parameters(param_dict)
 
     async def _do_execute(
         self,

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -19,7 +19,6 @@ from typing import (
 
 from httpx import URL, Headers, Response, codes
 
-from firebolt.async_db.util import ENGINE_STATUS_RUNNING_LIST
 from firebolt.client.client import AsyncClient, AsyncClientV1, AsyncClientV2
 from firebolt.common._types import (
     ColType,
@@ -44,6 +43,7 @@ from firebolt.common.base_cursor import (
     check_not_closed,
     check_query_executed,
 )
+from firebolt.common.constants import ENGINE_STATUS_RUNNING_LIST
 from firebolt.utils.exception import (
     AsyncExecutionUnavailableError,
     EngineNotRunningError,

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -453,7 +453,7 @@ class CursorV2(Cursor):
         if self.connection._is_system:
             assert isinstance(self._client, AsyncClientV2)
             parameters["account_id"] = await self._client.account_id
-        return self._client.request(
+        return await self._client.request(
             url=f"/{path}" if path else "",
             method="POST",
             params=parameters,
@@ -557,7 +557,7 @@ class CursorV1(Cursor):
             parameters = {**(self._set_parameters or {}), **(parameters or {})}
         if self.parameters:
             parameters = {**self.parameters, **parameters}
-        return self._client.request(
+        return await self._client.request(
             url=f"/{path}",
             method="POST",
             params={

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -89,6 +89,8 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         self.engine_url = connection.engine_url
         if connection.database:
             self.database = connection.database
+        if connection.init_parameters:
+            self._set_parameters = connection.init_parameters.copy()
 
     @abstractmethod
     async def _api_request(
@@ -514,7 +516,7 @@ class CursorV2(Cursor):
             # System engine is always running
             return True
 
-        engine_name = URL(engine_url).host.split(".")[0].replace("-", "_")
+        engine_name = self.get_engine_name(engine_url)
         assert self.connection._system_engine_connection is not None  # Type check
         system_cursor = self.connection._system_engine_connection.cursor()
         assert isinstance(system_cursor, CursorV2)  # Type check, should always be true

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -90,14 +90,6 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         if connection.database:
             self.database = connection.database
 
-    @property
-    def database(self) -> Optional[str]:
-        return self.parameters.get("database")
-
-    @database.setter
-    def database(self, database: str) -> None:
-        self.parameters["database"] = database
-
     @abstractmethod
     async def _api_request(
         self,

--- a/src/firebolt/async_db/util.py
+++ b/src/firebolt/async_db/util.py
@@ -11,8 +11,6 @@ from firebolt.utils.exception import (
 )
 from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
 
-ENGINE_STATUS_RUNNING_LIST = ["Running", "ENGINE_STATE_RUNNING"]
-
 
 async def _get_system_engine_url(
     auth: Auth,

--- a/src/firebolt/async_db/util.py
+++ b/src/firebolt/async_db/util.py
@@ -11,7 +11,7 @@ from firebolt.utils.exception import (
 )
 from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
 
-ENGINE_STATUS_RUNNING = "Running"
+ENGINE_STATUS_RUNNING_LIST = ["Running", "ENGINE_STATE_RUNNING"]
 
 
 async def _get_system_engine_url(

--- a/src/firebolt/client/constants.py
+++ b/src/firebolt/client/constants.py
@@ -5,7 +5,7 @@ from httpx import CookieConflict, HTTPError, InvalidURL, StreamError
 
 DEFAULT_API_URL: str = "api.app.firebolt.io"
 PROTOCOL_VERSION_HEADER_NAME = "Firebolt-Protocol-Version"
-PROTOCOL_VERSION: str = "2.0"
+PROTOCOL_VERSION: str = "2.1"
 _REQUEST_ERRORS: Tuple[Type, ...] = (
     HTTPError,
     InvalidURL,

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from httpx import URL, Response
 
-from firebolt.client.client import Client
 from firebolt.common._types import (
     ColType,
     Column,
@@ -160,7 +159,6 @@ class BaseCursor:
         "connection",
         "parameters",
         "_arraysize",
-        "_client",
         "_state",
         "_descriptions",
         "_statistics",
@@ -176,7 +174,7 @@ class BaseCursor:
 
     default_arraysize = 1
 
-    def __init__(self, *args: Any, client: Client, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._arraysize = self.default_arraysize
         # These fields initialized here for type annotations purpose
         self._rows: Optional[List[List[RawColType]]] = None
@@ -199,7 +197,6 @@ class BaseCursor:
         self._idx = 0
         self._next_set_idx = 0
         self._query_id = ""
-        self._client = client
         self._reset()
 
     @property  # type: ignore

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -159,6 +159,7 @@ class BaseCursor:
         "connection",
         "parameters",
         "_arraysize",
+        "_client",
         "_state",
         "_descriptions",
         "_statistics",
@@ -190,7 +191,7 @@ class BaseCursor:
         ] = []
         # User-defined set parameters
         self._set_parameters: Dict[str, Any] = dict()
-        # Server-side parameters
+        # Server-side parameters (user can't change them)
         self.parameters: Dict[str, str] = dict()
         self.engine_url = ""
         self._rowcount = -1
@@ -306,11 +307,15 @@ class BaseCursor:
 
     def _update_set_parameters(self, parameters: Dict[str, Any]) -> None:
         for key, value in parameters.items():
-            if key in DISALLOWED_PARAMETER_LIST:
-                # TODO: make this better
-                continue
-            else:
+            if key not in DISALLOWED_PARAMETER_LIST:
                 self._set_parameters[key] = value
+            else:
+                # This should never happen as user parameters are validated
+                # before they are sent to the server
+                logger.debug(
+                    f"Trying to set a disalloed parameter {key} from server. "
+                    "It will be ignored."
+                )
 
     def _update_server_parameters(self, parameters: Dict[str, Any]) -> None:
         for key, value in parameters.items():

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -199,6 +199,14 @@ class BaseCursor:
         self._query_id = ""
         self._reset()
 
+    @property
+    def database(self) -> Optional[str]:
+        return self.parameters.get("database")
+
+    @database.setter
+    def database(self, database: str) -> None:
+        self.parameters["database"] = database
+
     @property  # type: ignore
     @check_not_closed
     def description(self) -> Optional[List[Column]]:

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -58,7 +58,7 @@ USE_PARAMETER_LIST = ["database", "engine"]
 # parameters that can only be set by the backend
 DISALLOWED_PARAMETER_LIST = ["account_id", "output_format"]
 # parameters that are set by the backend and should not be set by the user
-IMMUATABLE_PARAMETER_LIST = USE_PARAMETER_LIST + DISALLOWED_PARAMETER_LIST
+IMMUTABLE_PARAMETER_LIST = USE_PARAMETER_LIST + DISALLOWED_PARAMETER_LIST
 
 UPDATE_ENDPOINT_HEADER = "Firebolt-Update-Endpoint"
 UPDATE_PARAMETERS_HEADER = "Firebolt-Update-Parameters"
@@ -309,12 +309,12 @@ class BaseCursor:
         immutable_parameters = {
             key: value
             for key, value in parameters.items()
-            if key in IMMUATABLE_PARAMETER_LIST
+            if key in IMMUTABLE_PARAMETER_LIST
         }
         user_parameters = {
             key: value
             for key, value in parameters.items()
-            if key not in IMMUATABLE_PARAMETER_LIST
+            if key not in IMMUTABLE_PARAMETER_LIST
         }
 
         self._update_server_parameters(immutable_parameters)

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -321,6 +321,17 @@ class BaseCursor:
                     f"Trying to set an unknown parameter {key}. " "It will be ignored."
                 )
 
+    def get_engine_name(self, engine_url: str) -> str:
+        """
+        Get the name of the engine that we're using.
+
+        Args:
+            engine_url (str): URL of the engine
+        """
+        if self._set_parameters.get("engine"):
+            return self._set_parameters["engine"]
+        return URL(engine_url).host.split(".")[0].replace("-", "_")
+
     def _row_set_from_response(
         self, response: Response
     ) -> Tuple[

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -326,16 +326,17 @@ class BaseCursor:
         for key, value in parameters.items():
             self.parameters[key] = value
 
-    def get_engine_name(self, engine_url: str) -> str:
+    @property
+    def engine_name(self) -> str:
         """
         Get the name of the engine that we're using.
 
         Args:
             engine_url (str): URL of the engine
         """
-        if self._set_parameters.get("engine"):
-            return self._set_parameters["engine"]
-        return URL(engine_url).host.split(".")[0].replace("-", "_")
+        if self.parameters.get("engine"):
+            return self.parameters["engine"]
+        return URL(self.engine_url).host.split(".")[0].replace("-", "_")
 
     def _row_set_from_response(
         self, response: Response

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -323,7 +323,7 @@ class BaseCursor:
                 self.parameters[key] = value
             else:
                 logger.debug(
-                    f"Trying to set an unknown parameter {key}. " "It will be ignored."
+                    f"Trying to set an unknown parameter {key}. It will be ignored."
                 )
 
     def get_engine_name(self, engine_url: str) -> str:

--- a/src/firebolt/common/base_cursor.py
+++ b/src/firebolt/common/base_cursor.py
@@ -317,10 +317,9 @@ class BaseCursor:
             if key not in IMMUTABLE_PARAMETER_LIST
         }
 
-        self._update_server_parameters(immutable_parameters)
+        self.parameters.update(immutable_parameters)
 
-        for key, value in user_parameters.items():
-            self._set_parameters[key] = value
+        self._set_parameters.update(user_parameters)
 
     def _update_server_parameters(self, parameters: Dict[str, Any]) -> None:
         for key, value in parameters.items():

--- a/src/firebolt/common/constants.py
+++ b/src/firebolt/common/constants.py
@@ -1,3 +1,6 @@
 KEEPALIVE_FLAG: int = 1
 KEEPIDLE_RATE: int = 60  # seconds
 DEFAULT_TIMEOUT_SECONDS: int = 60
+
+# Running statuses in infromation schema
+ENGINE_STATUS_RUNNING_LIST = ["Running", "ENGINE_STATE_RUNNING"]

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -12,7 +12,7 @@ from firebolt.client.auth import Auth
 from firebolt.common.base_connection import BaseConnection
 from firebolt.common.constants import DEFAULT_TIMEOUT_SECONDS
 from firebolt.db.cursor import Cursor, CursorV1, CursorV2
-from firebolt.db.util import _get_system_engine_url
+from firebolt.db.util import ENGINE_STATUS_RUNNING_LIST, _get_system_engine_url
 from firebolt.utils.exception import (
     ConfigurationError,
     ConnectionClosedError,
@@ -159,7 +159,7 @@ def connect_v2(
                 attached_db,
             ) = cursor._get_engine_url_status_db(system_engine_connection, engine_name)
 
-            if status != "Running":
+            if status not in ENGINE_STATUS_RUNNING_LIST:
                 raise EngineNotRunningError(engine_name)
 
             if database is not None and database != attached_db:

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -10,9 +10,12 @@ from httpx import Timeout
 from firebolt.client import DEFAULT_API_URL, Client, ClientV1, ClientV2
 from firebolt.client.auth import Auth
 from firebolt.common.base_connection import BaseConnection
-from firebolt.common.constants import DEFAULT_TIMEOUT_SECONDS
+from firebolt.common.constants import (
+    DEFAULT_TIMEOUT_SECONDS,
+    ENGINE_STATUS_RUNNING_LIST,
+)
 from firebolt.db.cursor import Cursor, CursorV1, CursorV2
-from firebolt.db.util import ENGINE_STATUS_RUNNING_LIST, _get_system_engine_url
+from firebolt.db.util import _get_system_engine_url
 from firebolt.utils.exception import (
     ConfigurationError,
     ConnectionClosedError,

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -147,7 +147,7 @@ def connect_v2(
             CursorV2,
             system_engine_connection,
             api_endpoint,
-            cursor._set_parameters,
+            cursor.parameters,
         )
 
     if not engine_name:

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -45,10 +45,10 @@ def connect(
     user_drivers = additional_parameters.get("user_drivers", [])
     user_clients = additional_parameters.get("user_clients", [])
     user_agent_header = get_user_agent_header(user_drivers, user_clients)
-    version = auth.get_firebolt_version()
+    auth_version = auth.get_firebolt_version()
     # Use v2 if auth is ClientCredentials
     # Use v1 if auth is ServiceAccount or UsernamePassword
-    if version == 2:
+    if auth_version == 2:
         assert account_name is not None
         return connect_v2(
             auth=auth,
@@ -58,7 +58,7 @@ def connect(
             engine_name=engine_name,
             api_endpoint=api_endpoint,
         )
-    elif version == 1:
+    elif auth_version == 1:
         return connect_v1(
             auth=auth,
             user_agent_header=user_agent_header,

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -87,14 +87,6 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         if connection.database:
             self.database = connection.database
 
-    @property
-    def database(self) -> Optional[str]:
-        return self.parameters.get("database")
-
-    @database.setter
-    def database(self, database: str) -> None:
-        self.parameters["database"] = database
-
     def _raise_if_error(self, resp: Response) -> None:
         """Raise a proper error if any"""
         if resp.status_code == codes.INTERNAL_SERVER_ERROR:

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -71,13 +71,12 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
     def __init__(
         self,
         *args: Any,
-        client: Client,
         connection: Connection,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self._client = client
         self.connection = connection
+        self.engine_url = connection.engine_url
         if connection.database:
             self.database = connection.database
 
@@ -104,9 +103,11 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         if (
             resp.status_code == codes.SERVICE_UNAVAILABLE
             or resp.status_code == codes.NOT_FOUND
-        ) and not self.is_engine_running(self.connection.engine_url):
+        ) and not self.is_engine_running(
+            self.engine_url
+        ):  # TODO: v2 acc conditional check
             raise EngineNotRunningError(
-                f"Firebolt engine {self.connection.engine_url} "
+                f"Firebolt engine {self.engine_url} "
                 "needs to be running to run queries against it."  # pragma: no mutate # noqa: E501
             )
         _print_error_body(resp)

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -41,7 +41,7 @@ from firebolt.common.base_cursor import (
     check_not_closed,
     check_query_executed,
 )
-from firebolt.db.util import ENGINE_STATUS_RUNNING_LIST
+from firebolt.common.constants import ENGINE_STATUS_RUNNING_LIST
 from firebolt.utils.exception import (
     AsyncExecutionUnavailableError,
     EngineNotRunningError,

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -396,7 +396,7 @@ class CursorV2(Cursor):
             parameters = {**(self._set_parameters or {}), **parameters}
         if self.parameters:
             parameters = {**self.parameters, **parameters}
-        if self.connection._is_system:
+        if self.connection._is_system or self._client.account_version == 2:
             assert isinstance(self._client, ClientV2)  # Type check
             parameters["account_id"] = self._client.account_id
         return self._client.request(

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -106,7 +106,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
             or resp.status_code == codes.NOT_FOUND
         ) and not self.is_engine_running(self.engine_url):
             raise EngineNotRunningError(
-                f"Firebolt engine {self.get_engine_name(self.engine_url)} "
+                f"Firebolt engine {self.engine_name} "
                 "needs to be running to run queries against it."  # pragma: no mutate # noqa: E501
             )
         _print_error_body(resp)
@@ -462,10 +462,9 @@ class CursorV2(Cursor):
             # System engine is always running
             return True
 
-        engine_name = self.get_engine_name(engine_url)
         assert self.connection._system_engine_connection is not None  # Type check
         _, status, _ = self._get_engine_url_status_db(
-            self.connection._system_engine_connection, engine_name
+            self.connection._system_engine_connection, self.engine_name
         )
         return status in ENGINE_STATUS_RUNNING_LIST
 

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -76,10 +76,12 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
     def __init__(
         self,
         *args: Any,
+        client: Client,
         connection: Connection,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self._client = client
         self.connection = connection
         self.engine_url = connection.engine_url
         if connection.database:
@@ -161,7 +163,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
                 )
             self._update_set_parameters(params)
             self.engine_url = endpoint
-            self._client.base_url = endpoint
+            self._client.base_url = URL(endpoint)
 
         if headers.get(RESET_SESSION_HEADER):
             self.flush_parameters()

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -41,7 +41,7 @@ from firebolt.common.base_cursor import (
     check_not_closed,
     check_query_executed,
 )
-from firebolt.db.util import ENGINE_STATUS_RUNNING
+from firebolt.db.util import ENGINE_STATUS_RUNNING_LIST
 from firebolt.utils.exception import (
     AsyncExecutionUnavailableError,
     EngineNotRunningError,
@@ -418,6 +418,7 @@ class CursorV2(Cursor):
             parameters = {**(self._set_parameters or {}), **parameters}
         if self.parameters:
             parameters = {**self.parameters, **parameters}
+        # Engines v2 always require account_id
         if self.connection._is_system or self._client._account_version == 2:
             assert isinstance(self._client, ClientV2)  # Type check
             parameters["account_id"] = self._client.account_id
@@ -466,7 +467,7 @@ class CursorV2(Cursor):
         _, status, _ = self._get_engine_url_status_db(
             self.connection._system_engine_connection, engine_name
         )
-        return status == ENGINE_STATUS_RUNNING
+        return status in ENGINE_STATUS_RUNNING_LIST
 
     def _get_engine_url_status_db(
         self, system_engine_connection: Connection, engine_name: str

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -87,7 +87,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         if connection.database:
             self.database = connection.database
         if connection.init_parameters:
-            self._set_parameters = connection.init_parameters.copy()
+            self._update_set_parameters(connection.init_parameters)
 
     def _raise_if_error(self, resp: Response) -> None:
         """Raise a proper error if any"""
@@ -162,7 +162,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
 
         if headers.get(UPDATE_PARAMETERS_HEADER):
             param_dict = _parse_update_parameters(headers.get(UPDATE_PARAMETERS_HEADER))
-            self._update_server_parameters(param_dict)
+            self._update_set_parameters(param_dict)
 
     def _do_execute(
         self,

--- a/src/firebolt/db/util.py
+++ b/src/firebolt/db/util.py
@@ -11,7 +11,7 @@ from firebolt.utils.exception import (
 )
 from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
 
-ENGINE_STATUS_RUNNING = "Running"
+ENGINE_STATUS_RUNNING_LIST = ["Running", "ENGINE_STATE_RUNNING"]
 
 
 def _get_system_engine_url(

--- a/src/firebolt/db/util.py
+++ b/src/firebolt/db/util.py
@@ -11,8 +11,6 @@ from firebolt.utils.exception import (
 )
 from firebolt.utils.urls import GATEWAY_HOST_BY_ACCOUNT_NAME
 
-ENGINE_STATUS_RUNNING_LIST = ["Running", "ENGINE_STATE_RUNNING"]
-
 
 def _get_system_engine_url(
     auth: Auth,

--- a/tests/integration/dbapi/async/V2/conftest.py
+++ b/tests/integration/dbapi/async/V2/conftest.py
@@ -76,6 +76,19 @@ async def connection_system_engine_v2(
 
 
 @fixture
+async def engine_v2(
+    connection_system_engine_v2: Connection,
+    engine_name: str,
+) -> str:
+    cursor = connection_system_engine_v2.cursor()
+    await cursor.execute(f"CREATE ENGINE IF NOT EXISTS {engine_name}")
+    await cursor.execute(f"START ENGINE {engine_name}")
+    yield engine_name
+    await cursor.execute(f"STOP ENGINE {engine_name}")
+    await cursor.execute(f"DROP ENGINE IF EXISTS {engine_name}")
+
+
+@fixture
 async def connection_system_engine_no_db(
     auth: Auth,
     account_name: str,

--- a/tests/integration/dbapi/async/V2/conftest.py
+++ b/tests/integration/dbapi/async/V2/conftest.py
@@ -61,13 +61,11 @@ async def connection_system_engine(
 
 @fixture
 async def connection_system_engine_v2(
-    database_name: str,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
 ) -> Connection:
     async with await connect(
-        database=database_name,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -282,7 +282,7 @@ async def test_parameterized_query(connection: Connection) -> None:
 
         assert_deep_eq(
             await c.fetchall(),
-            [params + ["?"]],
+            [params + ["\\?"]],
             "Invalid data in table after parameterized insert",
         )
 
@@ -449,15 +449,13 @@ async def setup_db(connection_system_engine_v2: Connection, use_db_name: str):
 async def test_use_database(
     setup_db,
     connection_system_engine_no_db: Connection,
-    use_db_name: str,
     database_name: str,
 ) -> None:
-    test_db_name = use_db_name + "_async"
     test_table_name = "verify_use_db_async"
     """Use database works as expected."""
     with connection_system_engine_no_db.cursor() as c:
-        await c.execute(f"USE DATABASE {test_db_name}")
-        assert c.database == test_db_name
+        await c.execute(f"USE DATABASE {setup_db}")
+        assert c.database == setup_db
         await c.execute(f"CREATE TABLE {test_table_name} (id int)")
         await c.execute(
             "SELECT table_name FROM information_schema.tables "
@@ -476,13 +474,12 @@ async def test_use_database(
 
 async def test_account_v2_connection_with_db(
     setup_db: Generator,
-    use_db_name: str,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
 ) -> None:
     async with await connect(
-        database=use_db_name,
+        database=setup_db,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,
@@ -496,7 +493,6 @@ async def test_account_v2_connection_with_db(
 async def test_account_v2_connection_with_db_and_engine(
     setup_db: Generator,
     connection_system_engine_v2: Connection,
-    use_db_name: str,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
@@ -507,7 +503,7 @@ async def test_account_v2_connection_with_db_and_engine(
     # via the system connection to keep test isolated
     await system_cursor.execute(f"START ENGINE {engine_v2}")
     async with await connect(
-        database=use_db_name,
+        database=setup_db,
         engine_name=engine_v2,
         auth=auth,
         account_name=account_name_v2,

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -435,7 +435,7 @@ async def test_bytea_roundtrip(
 
 
 @fixture
-async def setup_db(connection_system_engine_v2: Connection, use_db_name: str):
+async def setup_v2_db(connection_system_engine_v2: Connection, use_db_name: str):
     use_db_name = use_db_name + "_async"
     with connection_system_engine_v2.cursor() as cursor:
         # randomize the db name to avoid conflicts
@@ -447,15 +447,15 @@ async def setup_db(connection_system_engine_v2: Connection, use_db_name: str):
 
 @mark.xfail("dev" not in environ[API_ENDPOINT_ENV], reason="Only works on dev")
 async def test_use_database(
-    setup_db,
+    setup_v2_db,
     connection_system_engine_no_db: Connection,
     database_name: str,
 ) -> None:
     test_table_name = "verify_use_db_async"
     """Use database works as expected."""
     with connection_system_engine_no_db.cursor() as c:
-        await c.execute(f"USE DATABASE {setup_db}")
-        assert c.database == setup_db
+        await c.execute(f"USE DATABASE {setup_v2_db}")
+        assert c.database == setup_v2_db
         await c.execute(f"CREATE TABLE {test_table_name} (id int)")
         await c.execute(
             "SELECT table_name FROM information_schema.tables "
@@ -473,13 +473,13 @@ async def test_use_database(
 
 
 async def test_account_v2_connection_with_db(
-    setup_db: Generator,
+    setup_v2_db: Generator,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
 ) -> None:
     async with await connect(
-        database=setup_db,
+        database=setup_v2_db,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,
@@ -491,7 +491,7 @@ async def test_account_v2_connection_with_db(
 
 
 async def test_account_v2_connection_with_db_and_engine(
-    setup_db: Generator,
+    setup_v2_db: Generator,
     connection_system_engine_v2: Connection,
     auth: Auth,
     account_name_v2: str,
@@ -503,7 +503,7 @@ async def test_account_v2_connection_with_db_and_engine(
     # via the system connection to keep test isolated
     await system_cursor.execute(f"START ENGINE {engine_v2}")
     async with await connect(
-        database=setup_db,
+        database=setup_v2_db,
         engine_name=engine_v2,
         auth=auth,
         account_name=account_name_v2,

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from os import environ
 from random import choice, randint
-from typing import Callable, List
+from typing import Callable, Generator, List
 
 from pytest import fixture, mark, raises
 
@@ -471,10 +471,14 @@ async def test_use_database(
 
 
 async def test_account_v2_connection_with_db(
-    database_name: str, auth: Auth, account_name_v2: str, api_endpoint: str
+    setup_db: Generator,
+    use_db_name: str,
+    auth: Auth,
+    account_name_v2: str,
+    api_endpoint: str,
 ) -> None:
     async with await connect(
-        database=database_name,
+        database=use_db_name,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,
@@ -486,8 +490,9 @@ async def test_account_v2_connection_with_db(
 
 
 async def test_account_v2_connection_with_db_and_engine(
+    setup_db: Generator,
     connection_system_engine_v2: Connection,
-    database_name: str,
+    use_db_name: str,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
@@ -498,7 +503,7 @@ async def test_account_v2_connection_with_db_and_engine(
     # via the system connection to keep test isolated
     await system_cursor.execute(f"START ENGINE {engine_v2}")
     async with await connect(
-        database=database_name,
+        database=use_db_name,
         engine_name=engine_v2,
         auth=auth,
         account_name=account_name_v2,

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -411,6 +411,9 @@ async def test_bytea_roundtrip(
 ) -> None:
     """Inserted and than selected bytea value doesn't get corrupted."""
     with connection.cursor() as c:
+        # Set standard_conforming_strings to 0 to allow bytea escape sequences
+        # FIR-30650
+        await c.execute("SET standard_conforming_strings=0")
         await c.execute("DROP TABLE IF EXISTS test_bytea_roundtrip_2")
         await c.execute(
             "CREATE FACT TABLE test_bytea_roundtrip_2(id int, b bytea) primary index id"
@@ -425,6 +428,7 @@ async def test_bytea_roundtrip(
 
         bytes_data = (await c.fetchone())[0]
 
+        await c.execute("SET standard_conforming_strings=1")
         assert (
             bytes_data.decode("utf-8") == data
         ), "Invalid bytea data returned after roundtrip"

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -274,7 +274,7 @@ async def test_parameterized_query(connection: Connection) -> None:
         )
 
         # \0 is converted to 0
-        params[2] = "text0"
+        params[2] = "text\\0"
 
         assert (
             await c.execute("SELECT * FROM test_tb_async_parameterized") == 1
@@ -435,13 +435,13 @@ async def test_bytea_roundtrip(
 
 
 @fixture
-async def setup_db(connection_system_engine_no_db: Connection, use_db_name: str):
+async def setup_db(connection_system_engine_v2: Connection, use_db_name: str):
     use_db_name = use_db_name + "_async"
-    with connection_system_engine_no_db.cursor() as cursor:
+    with connection_system_engine_v2.cursor() as cursor:
         # randomize the db name to avoid conflicts
         suffix = "".join(choice("0123456789") for _ in range(2))
         await cursor.execute(f"CREATE DATABASE {use_db_name}{suffix}")
-        yield
+        yield f"{use_db_name}{suffix}"
         await cursor.execute(f"DROP DATABASE {use_db_name}{suffix}")
 
 

--- a/tests/integration/dbapi/async/V2/test_system_engine_async.py
+++ b/tests/integration/dbapi/async/V2/test_system_engine_async.py
@@ -80,3 +80,21 @@ async def test_system_engine_v2_account(connection_system_engine_v2: Connection)
     assert (
         await connection_system_engine_v2._client._account_version
     ) == 2, "Invalid account version"
+
+
+async def test_system_engine_use_engine(
+    connection_system_engine_v2: Connection, database_name: str, engine_name: str
+):
+    with connection_system_engine_v2.cursor() as cursor:
+        await cursor.execute(f"CREATE DATABASE IF NOT EXISTS {database_name}")
+        await cursor.execute(f"USE DATABASE {database_name}")
+        await cursor.execute(f"CREATE ENGINE IF NOT EXISTS {engine_name}")
+        await cursor.execute(f"USE ENGINE {engine_name}")
+        await cursor.execute("CREATE TABLE IF NOT EXISTS test_table (id int)")
+        # This query fails if we're not on a user engine
+        await cursor.execute("INSERT INTO test_table VALUES (1)")
+        await cursor.execute("USE ENGINE system")
+        # Werify we've switched to system by making previous query fail
+        with raises(OperationalError):
+            await cursor.execute("INSERT INTO test_table VALUES (1)")
+        await cursor.execute("DROP TABLE IF EXISTS test_table")

--- a/tests/integration/dbapi/sync/V2/conftest.py
+++ b/tests/integration/dbapi/sync/V2/conftest.py
@@ -59,20 +59,31 @@ def connection_system_engine(
         yield connection
 
 
-@fixture
+@fixture(scope="session")
 def connection_system_engine_v2(
-    database_name: str,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
 ) -> Connection:
     with connect(
-        database=database_name,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,
     ) as connection:
         yield connection
+
+
+@fixture(scope="session")
+def engine_v2(
+    connection_system_engine_v2: Connection,
+    engine_name: str,
+) -> str:
+    cursor = connection_system_engine_v2.cursor()
+    cursor.execute(f"CREATE ENGINE IF NOT EXISTS {engine_name}")
+    cursor.execute(f"START ENGINE {engine_name}")
+    yield engine_name
+    cursor.execute(f"STOP ENGINE {engine_name}")
+    cursor.execute(f"DROP ENGINE IF EXISTS {engine_name}")
 
 
 @fixture

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -494,6 +494,9 @@ def test_bytea_roundtrip(
 ) -> None:
     """Inserted and than selected bytea value doesn't get corrupted."""
     with connection.cursor() as c:
+        # Set standard_conforming_strings to 0 to allow bytea escape sequences
+        # FIR-30650
+        c.execute("SET standard_conforming_strings=0")
         c.execute("DROP TABLE IF EXISTS test_bytea_roundtrip")
         c.execute(
             "CREATE FACT TABLE test_bytea_roundtrip(id int, b bytea) primary index id"
@@ -505,7 +508,7 @@ def test_bytea_roundtrip(
         c.execute("SELECT b FROM test_bytea_roundtrip")
 
         bytes_data = (c.fetchone())[0]
-
+        c.execute("SET standard_conforming_strings=1")
         assert (
             bytes_data.decode("utf-8") == data
         ), "Invalid bytea data returned after roundtrip"

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -2,7 +2,7 @@ import math
 from datetime import date, datetime
 from decimal import Decimal
 from os import environ
-from random import randint
+from random import choice, randint
 from threading import Thread
 from typing import Any, Callable, Generator, List
 
@@ -283,7 +283,7 @@ def test_parameterized_query(connection: Connection) -> None:
 
         assert_deep_eq(
             c.fetchall(),
-            [params + ["?"]],
+            [params + ["\\?"]],
             "Invalid data in table after parameterized insert",
         )
 

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -514,7 +514,7 @@ def test_bytea_roundtrip(
         ), "Invalid bytea data returned after roundtrip"
 
 
-@fixture
+@fixture(scope="module")
 def setup_db(connection_system_engine_v2, use_db_name):
     use_db_name = f"{use_db_name}_sync"
     with connection_system_engine_v2.cursor() as cursor:

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from os import environ
 from random import randint
 from threading import Thread
-from typing import Any, Callable, List
+from typing import Any, Callable, Generator, List
 
 from pytest import fixture, mark, raises
 
@@ -550,10 +550,14 @@ def test_use_database(
 
 
 def test_account_v2_connection_with_db(
-    database_name: str, auth: Auth, account_name_v2: str, api_endpoint: str
+    setup_db: Generator,
+    use_db_name: str,
+    auth: Auth,
+    account_name_v2: str,
+    api_endpoint: str,
 ) -> None:
     with connect(
-        database=database_name,
+        database=use_db_name,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,
@@ -563,8 +567,9 @@ def test_account_v2_connection_with_db(
 
 
 def test_account_v2_connection_with_db_and_engine(
+    setup_db: Generator,
     connection_system_engine_v2: Connection,
-    database_name: str,
+    use_db_name: str,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
@@ -575,7 +580,7 @@ def test_account_v2_connection_with_db_and_engine(
     # via the system connection to keep test isolated
     system_cursor.execute(f"START ENGINE {engine_v2}")
     with connect(
-        database=database_name,
+        database=use_db_name,
         engine_name=engine_v2,
         auth=auth,
         account_name=account_name_v2,

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -515,7 +515,7 @@ def test_bytea_roundtrip(
 
 
 @fixture(scope="module")
-def setup_db(connection_system_engine_v2, use_db_name):
+def setup_v2_db(connection_system_engine_v2, use_db_name):
     use_db_name = f"{use_db_name}_sync"
     with connection_system_engine_v2.cursor() as cursor:
         # randomize the db name to avoid conflicts
@@ -527,15 +527,15 @@ def setup_db(connection_system_engine_v2, use_db_name):
 
 @mark.xfail("dev" not in environ[API_ENDPOINT_ENV], reason="Only works on dev")
 def test_use_database(
-    setup_db,
+    setup_v2_db,
     connection_system_engine: Connection,
     database_name: str,
 ) -> None:
     test_table_name = "verify_use_db"
     """Use database works as expected."""
     with connection_system_engine.cursor() as c:
-        c.execute(f"USE DATABASE {setup_db}")
-        assert c.database == setup_db
+        c.execute(f"USE DATABASE {setup_v2_db}")
+        assert c.database == setup_v2_db
         c.execute(f"CREATE TABLE {test_table_name} (id int)")
         c.execute(
             "SELECT table_name FROM information_schema.tables "
@@ -553,13 +553,13 @@ def test_use_database(
 
 
 def test_account_v2_connection_with_db(
-    setup_db: Generator,
+    setup_v2_db: Generator,
     auth: Auth,
     account_name_v2: str,
     api_endpoint: str,
 ) -> None:
     with connect(
-        database=setup_db,
+        database=setup_v2_db,
         auth=auth,
         account_name=account_name_v2,
         api_endpoint=api_endpoint,
@@ -569,7 +569,7 @@ def test_account_v2_connection_with_db(
 
 
 def test_account_v2_connection_with_db_and_engine(
-    setup_db: Generator,
+    setup_v2_db: Generator,
     connection_system_engine_v2: Connection,
     auth: Auth,
     account_name_v2: str,
@@ -581,7 +581,7 @@ def test_account_v2_connection_with_db_and_engine(
     # via the system connection to keep test isolated
     system_cursor.execute(f"START ENGINE {engine_v2}")
     with connect(
-        database=setup_db,
+        database=setup_v2_db,
         engine_name=engine_v2,
         auth=auth,
         account_name=account_name_v2,

--- a/tests/integration/dbapi/sync/V2/test_system_engine.py
+++ b/tests/integration/dbapi/sync/V2/test_system_engine.py
@@ -80,3 +80,21 @@ def test_system_engine_v2_account(connection_system_engine_v2: Connection):
     assert (
         connection_system_engine_v2._client._account_version == 2
     ), "Invalid account version"
+
+
+def test_system_engine_use_engine(
+    connection_system_engine_v2: Connection, database_name: str, engine_name: str
+):
+    with connection_system_engine_v2.cursor() as cursor:
+        cursor.execute(f"CREATE DATABASE IF NOT EXISTS {database_name}")
+        cursor.execute(f"USE DATABASE {database_name}")
+        cursor.execute(f"CREATE ENGINE IF NOT EXISTS {engine_name}")
+        cursor.execute(f"USE ENGINE {engine_name}")
+        cursor.execute("CREATE TABLE IF NOT EXISTS test_table (id int)")
+        # This query fails if we're not on a user engine
+        cursor.execute("INSERT INTO test_table VALUES (1)")
+        cursor.execute("USE ENGINE system")
+        # Werify we've switched to system by making previous query fail
+        with raises(OperationalError):
+            cursor.execute("INSERT INTO test_table VALUES (1)")
+        cursor.execute("DROP TABLE IF EXISTS test_table")

--- a/tests/unit/async_db/V2/conftest.py
+++ b/tests/unit/async_db/V2/conftest.py
@@ -24,6 +24,8 @@ async def connection(
             api_endpoint=server,
         )
     ) as connection:
+        # cache account_id for tests
+        await connection._client.account_id
         yield connection
 
 

--- a/tests/unit/async_db/V2/test_cursor.py
+++ b/tests/unit/async_db/V2/test_cursor.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, List
 from unittest.mock import patch
 
-from httpx import HTTPStatusError, StreamError, codes
+from httpx import URL, HTTPStatusError, Request, StreamError, codes
 from pytest import LogCaptureFixture, mark, raises
 from pytest_httpx import HTTPXMock
 
@@ -913,3 +913,119 @@ async def test_disallowed_set_parameter(cursor: Cursor, parameter: str) -> None:
         e.value
     ), "invalid error"
     assert cursor._set_parameters == {}, "set parameters should not be updated"
+
+
+async def test_cursor_use_engine_no_parameters(
+    httpx_mock: HTTPXMock,
+    query_url: URL,
+    cursor: Cursor,
+    query_statistics: Dict[str, Any],
+):
+    query_updated_url = "my_dummy_url"
+
+    def query_callback_with_headers(request: Request, **kwargs) -> Response:
+        assert request.read() != b""
+        assert request.method == "POST"
+        query_response = {
+            "meta": [{"name": "one", "type": "int"}],
+            "data": [1],
+            "rows": 1,
+            "statistics": query_statistics,
+        }
+        headers = {"Firebolt-Update-Endpoint": f"https://{query_updated_url}"}
+        return Response(status_code=codes.OK, json=query_response, headers=headers)
+
+    httpx_mock.add_callback(query_callback_with_headers, url=query_url)
+    assert cursor.engine_url == "https://" + query_url.host
+    await cursor.execute("USE ENGINE = 'my_dummy_engine'")
+    assert cursor.engine_url == f"https://{query_updated_url}"
+
+    httpx_mock.reset(True)
+    # Check updated engine is used in the next query
+    new_url = query_url.copy_with(host=query_updated_url)
+    httpx_mock.add_callback(query_callback_with_headers, url=new_url)
+    await cursor.execute("select 1")
+    assert cursor.engine_url == f"https://{query_updated_url}"
+
+
+async def test_cursor_use_engine_with_parameters(
+    httpx_mock: HTTPXMock,
+    query_url: URL,
+    cursor: Cursor,
+    query_statistics: Dict[str, Any],
+):
+    query_updated_url = "my_dummy_url"
+    param_string_dummy = "param1=1&param2=2"
+
+    header = {
+        "Firebolt-Update-Endpoint": f"https://{query_updated_url}/?{param_string_dummy}"
+    }
+
+    def query_callback_with_headers(request: Request, **kwargs) -> Response:
+        assert request.read() != b""
+        assert request.method == "POST"
+        query_response = {
+            "meta": [{"name": "one", "type": "int"}],
+            "data": [1],
+            "rows": 1,
+            "statistics": query_statistics,
+        }
+        headers = header
+        return Response(status_code=codes.OK, json=query_response, headers=headers)
+
+    httpx_mock.add_callback(query_callback_with_headers, url=query_url)
+    assert cursor.engine_url == "https://" + query_url.host
+    await cursor.execute("USE ENGINE = 'my_dummy_engine'")
+    assert cursor.engine_url == f"https://{query_updated_url}"
+    assert cursor._set_parameters == {"param1": "1", "param2": "2"}
+    assert list(cursor.parameters.keys()) == ["database"]
+
+    httpx_mock.reset(True)
+    # Check new parameters are used in the URL
+    new_url = query_url.copy_with(host=query_updated_url).copy_merge_params(
+        {"param1": "1", "param2": "2"}
+    )
+    httpx_mock.add_callback(query_callback_with_headers, url=new_url)
+    await cursor.execute("select 1")
+    assert cursor.engine_url == f"https://{query_updated_url}"
+
+
+async def test_cursor_reset_session(
+    httpx_mock: HTTPXMock,
+    select_one_query_callback: Callable,
+    set_query_url: str,
+    cursor: Cursor,
+    query_statistics: Dict[str, Any],
+):
+    def query_callback_with_headers(request: Request, **kwargs) -> Response:
+        assert request.read() != b""
+        assert request.method == "POST"
+        query_response = {
+            "meta": [{"name": "one", "type": "int"}],
+            "data": [1],
+            "rows": 1,
+            "statistics": query_statistics,
+        }
+        headers = {"Firebolt-Reset-Session": "any_value_here"}
+        return Response(status_code=codes.OK, json=query_response, headers=headers)
+
+    httpx_mock.add_callback(select_one_query_callback, url=f"{set_query_url}&a=b")
+
+    assert len(cursor._set_parameters) == 0
+
+    await cursor.execute("set a = b")
+    assert (
+        len(cursor._set_parameters) == 1
+        and "a" in cursor._set_parameters
+        and cursor._set_parameters["a"] == "b"
+    )
+
+    httpx_mock.reset(True)
+    httpx_mock.add_callback(
+        query_callback_with_headers,
+        url=f"{set_query_url}&a=b&output_format=JSON_Compact",
+    )
+    await cursor.execute("SELECT 1")
+    assert len(cursor._set_parameters) == 0
+    assert bool(cursor.engine_url) is True, "engine url is not set"
+    assert bool(cursor.database) is True, "database is not set"

--- a/tests/unit/async_db/V2/test_cursor.py
+++ b/tests/unit/async_db/V2/test_cursor.py
@@ -955,7 +955,7 @@ async def test_cursor_use_engine_with_parameters(
     query_statistics: Dict[str, Any],
 ):
     query_updated_url = "my_dummy_url"
-    param_string_dummy = "param1=1&param2=2"
+    param_string_dummy = "param1=1&param2=2&engine=my_dummy_engine"
 
     header = {
         "Firebolt-Update-Endpoint": f"https://{query_updated_url}/?{param_string_dummy}"
@@ -978,12 +978,13 @@ async def test_cursor_use_engine_with_parameters(
     await cursor.execute("USE ENGINE = 'my_dummy_engine'")
     assert cursor.engine_url == f"https://{query_updated_url}"
     assert cursor._set_parameters == {"param1": "1", "param2": "2"}
-    assert list(cursor.parameters.keys()) == ["database"]
+    assert list(cursor.parameters.keys()) == ["database", "engine"]
+    assert cursor.engine_name == "my_dummy_engine"
 
     httpx_mock.reset(True)
     # Check new parameters are used in the URL
     new_url = query_url.copy_with(host=query_updated_url).copy_merge_params(
-        {"param1": "1", "param2": "2"}
+        {"param1": "1", "param2": "2", "engine": "my_dummy_engine"}
     )
     httpx_mock.add_callback(query_callback_with_headers, url=new_url)
     await cursor.execute("select 1")

--- a/tests/unit/common/test_base_cursor.py
+++ b/tests/unit/common/test_base_cursor.py
@@ -50,7 +50,7 @@ def test_update_server_parameters_known_params(
     initial_parameters: Dict[str, str], cursor: BaseCursor
 ):
     cursor.parameters = initial_parameters
-    cursor._update_server_parameters({"database": "new_database"})
+    cursor._update_set_parameters({"database": "new_database"})
 
     # Merge the dictionaries using the update() method
     updated_parameters = initial_parameters.copy()

--- a/tests/unit/common/test_base_cursor.py
+++ b/tests/unit/common/test_base_cursor.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict
 from unittest.mock import MagicMock
 
 from pytest import fixture, mark
@@ -13,27 +14,60 @@ def cursor():
     return cursor
 
 
+@fixture
+def initial_parameters() -> Dict[str, str]:
+    return {"key1": "value1", "key2": "value2"}
+
+
 @mark.parametrize(
-    "headers, expected_parameters",
+    "set_params, expected",
     [
         (
-            {"Firebolt-Update-Parameters": "database=value1, key2=value2"},
-            {"database": "value1"},
+            {"key2": "new_value2", "key3": "value3"},
+            {"key1": "value1", "key2": "new_value2", "key3": "value3"},
         ),
-        (
-            {"Firebolt-Update-Parameters": "database =    value1  ,key3=  value3 "},
-            {"database": "value1"},
-        ),
+        ({}, {"key1": "value1", "key2": "value2"}),
     ],
 )
-def test_parse_response_headers(headers, expected_parameters, cursor, caplog):
-    # Capture the debug messages
-    with caplog.at_level(logging.DEBUG, logger="firebolt.common.base_cursor"):
-        # Call the function with the mock headers
-        cursor._parse_response_headers(headers)
-
+def test_update_set_parameters(
+    set_params: Dict[str, str],
+    expected: Dict[str, str],
+    initial_parameters: Dict[str, str],
+    cursor: BaseCursor,
+):
+    cursor._set_parameters = initial_parameters
+    cursor._update_set_parameters(set_params)
     # Assert that the parameters have been correctly updated
-    assert cursor.parameters == expected_parameters
+    assert cursor._set_parameters == expected
 
-    # Check that the debug message has been logged
-    assert "Unknown parameter" in caplog.text
+
+def test_flush_parameters(initial_parameters: Dict[str, str], cursor: BaseCursor):
+    cursor._set_parameters = initial_parameters
+    cursor.flush_parameters()
+    assert cursor._set_parameters == {}
+
+
+def test_update_server_parameters_unknown_params(
+    initial_parameters: Dict[str, str], cursor: BaseCursor, caplog
+):
+    cursor.parameters = initial_parameters
+
+    with caplog.at_level(logging.DEBUG, logger="firebolt.common.base_cursor"):
+        cursor._update_server_parameters({"key2": "new_value2", "key3": "value3"})
+
+    assert "unknown parameter" in caplog.text
+
+    # Assert that the parameters have not been modified
+    assert cursor.parameters == initial_parameters
+
+
+def test_update_server_parameters_known_params(
+    initial_parameters: Dict[str, str], cursor: BaseCursor
+):
+    cursor.parameters = initial_parameters
+    cursor._update_server_parameters({"database": "new_database"})
+
+    # Merge the dictionaries using the update() method
+    updated_parameters = initial_parameters.copy()
+    updated_parameters.update({"database": "new_database"})
+    assert cursor.parameters == updated_parameters

--- a/tests/unit/common/test_base_cursor.py
+++ b/tests/unit/common/test_base_cursor.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Dict
 from unittest.mock import MagicMock
 
@@ -45,20 +44,6 @@ def test_flush_parameters(initial_parameters: Dict[str, str], cursor: BaseCursor
     cursor._set_parameters = initial_parameters
     cursor.flush_parameters()
     assert cursor._set_parameters == {}
-
-
-def test_update_server_parameters_unknown_params(
-    initial_parameters: Dict[str, str], cursor: BaseCursor, caplog
-):
-    cursor.parameters = initial_parameters
-
-    with caplog.at_level(logging.DEBUG, logger="firebolt.common.base_cursor"):
-        cursor._update_server_parameters({"key2": "new_value2", "key3": "value3"})
-
-    assert "unknown parameter" in caplog.text
-
-    # Assert that the parameters have not been modified
-    assert cursor.parameters == initial_parameters
 
 
 def test_update_server_parameters_known_params(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,6 +59,11 @@ def client_secret() -> str:
 
 
 @fixture
+def server_name() -> str:
+    return "api_dev"
+
+
+@fixture
 def server() -> str:
     return "api-dev.mock.firebolt.io"
 
@@ -234,6 +239,11 @@ def engine_endpoint() -> str:
 @fixture
 def engine_name() -> str:
     return "mock_engine_name"
+
+
+@fixture
+def engine_url(engine_name: str) -> str:
+    return f"{engine_name}.mock.firebolt.io"
 
 
 @fixture

--- a/tests/unit/db/V2/conftest.py
+++ b/tests/unit/db/V2/conftest.py
@@ -23,6 +23,8 @@ def connection(
         account_name=account_name,
         api_endpoint=server,
     ) as connection:
+        # cache account_id for tests
+        connection._client.account_id
         yield connection
 
 

--- a/tests/unit/db/V2/test_cursor.py
+++ b/tests/unit/db/V2/test_cursor.py
@@ -189,7 +189,7 @@ def test_cursor_execute(
 def test_cursor_execute_error(
     httpx_mock: HTTPXMock,
     get_engines_url: str,
-    server: str,
+    server_name: str,
     db_name: str,
     query_url: str,
     query_statistics: Dict[str, Any],
@@ -323,7 +323,7 @@ def test_cursor_execute_error(
         with raises(EngineNotRunningError) as excinfo:
             query()
         assert cursor._state == CursorState.ERROR
-        assert server in str(excinfo)
+        assert server_name in str(excinfo)
 
         # Engine does not exist
         httpx_mock.add_callback(

--- a/tests/unit/db/V2/test_cursor.py
+++ b/tests/unit/db/V2/test_cursor.py
@@ -860,7 +860,7 @@ def test_cursor_use_engine_with_parameters(
     query_statistics: Dict[str, Any],
 ):
     query_updated_url = "my_dummy_url"
-    param_string_dummy = "param1=1&param2=2"
+    param_string_dummy = "param1=1&param2=2&engine=my_dummy_engine"
 
     header = {
         "Firebolt-Update-Endpoint": f"https://{query_updated_url}/?{param_string_dummy}"
@@ -883,12 +883,13 @@ def test_cursor_use_engine_with_parameters(
     cursor.execute("USE ENGINE = 'my_dummy_engine'")
     assert cursor.engine_url == f"https://{query_updated_url}"
     assert cursor._set_parameters == {"param1": "1", "param2": "2"}
-    assert list(cursor.parameters.keys()) == ["database"]
+    assert list(cursor.parameters.keys()) == ["database", "engine"]
+    assert cursor.engine_name == "my_dummy_engine"
 
     httpx_mock.reset(True)
     # Check new parameters are used in the URL
     new_url = query_url.copy_with(host=query_updated_url).copy_merge_params(
-        {"param1": "1", "param2": "2"}
+        {"param1": "1", "param2": "2", "engine": "my_dummy_engine"}
     )
     httpx_mock.add_callback(query_callback_with_headers, url=new_url)
     cursor.execute("select 1")


### PR DESCRIPTION
FIR-30151

Support decoupling of databases and engines (USE DATABASE, USE ENGINES).

Design decisions:
* Connection object holds initial database/engine that's specified by the user. All cursors created from it inherit these, but also keep them local. This means that cursors change on execution of "USE DATABASE/ENGINE" where they're connected to, but any new cursors from a connection will start from the initial configuration.
* `init_parameters` in connection used for parameters that server side returns from USE command. On connect() we execute these queries on system engine if the user supplied database/engine and pass the resulting parameters to the Connection constructor. This ensures connection is initialised as per user parameters.
* ENGINE_STATUS is now a list, since engines V2 and engines V1 statuses are different.
* Common properties (database) in cursor moved to the base class, since they're used in both cursor versions.
* Response header parsing is refactored to a base class since it's common for sync and async. 