### PR TITLE
test: Fix string checks

### DIFF
--- a/tests/integration/dbapi/async/V1/test_queries_async.py
+++ b/tests/integration/dbapi/async/V1/test_queries_async.py
@@ -344,9 +344,6 @@ async def test_parameterized_query(connection: Connection) -> None:
             params,
         )
 
-        # \0 is converted to 0
-        params[2] = "text0"
-
         assert (
             await c.execute("SELECT * FROM test_tb_async_parameterized") == 1
         ), "Invalid data length in table after parameterized insert"
@@ -488,6 +485,10 @@ async def test_bytea_roundtrip(
         )
 
         data = "bytea_123\n\tヽ༼ຈل͜ຈ༽ﾉ"
+
+        await c.execute(
+            "SET standard_conforming_strings=0"
+        )  # to allow backslashes in bytea
 
         await c.execute(
             "INSERT INTO test_bytea_roundtrip VALUES (1, ?)", (Binary(data),)

--- a/tests/integration/dbapi/async/V1/test_queries_async.py
+++ b/tests/integration/dbapi/async/V1/test_queries_async.py
@@ -325,6 +325,8 @@ async def test_parameterized_query(connection: Connection) -> None:
             "dec decimal(38, 3), ss string) primary index i",
         )
 
+        await c.execute("SET standard_conforming_strings=0")  # or \0 is incorrect
+
         params = [
             1,
             1.123,

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -252,6 +252,8 @@ async def test_parameterized_query(connection: Connection) -> None:
             "dec decimal(38, 3), ss string) primary index i",
         )
 
+        await c.execute("SET standard_conforming_strings=0")  # or \0 is incorrect
+
         params = [
             1,
             1.123,

--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -271,9 +271,6 @@ async def test_parameterized_query(connection: Connection) -> None:
             params,
         )
 
-        # \0 is converted to 0
-        params[2] = "text0"
-
         assert (
             await c.execute("SELECT * FROM test_tb_async_parameterized") == 1
         ), "Invalid data length in table after parameterized insert"
@@ -415,6 +412,10 @@ async def test_bytea_roundtrip(
         )
 
         data = "bytea_123\n\tヽ༼ຈل͜ຈ༽ﾉ"
+
+        await c.execute(
+            "SET standard_conforming_strings=0"
+        )  # to allow backslashes in bytea
 
         await c.execute(
             "INSERT INTO test_bytea_roundtrip_2 VALUES (1, ?)", (Binary(data),)

--- a/tests/integration/dbapi/sync/V1/test_queries.py
+++ b/tests/integration/dbapi/sync/V1/test_queries.py
@@ -269,6 +269,8 @@ def test_parameterized_query(connection: Connection) -> None:
             "dec decimal(38, 3), ss string) primary index i",
         )
 
+        c.execute("SET standard_conforming_strings=0")  # or \0 is incorrect
+
         params = [
             1,
             1.123,

--- a/tests/integration/dbapi/sync/V1/test_queries.py
+++ b/tests/integration/dbapi/sync/V1/test_queries.py
@@ -288,9 +288,6 @@ def test_parameterized_query(connection: Connection) -> None:
             params,
         )
 
-        # \0 is converted to 0
-        params[2] = "text0"
-
         assert (
             c.execute("SELECT * FROM test_tb_parameterized") == 1
         ), "Invalid data length in table after parameterized insert"
@@ -514,6 +511,8 @@ def test_bytea_roundtrip(
         )
 
         data = "bytea_123\n\tヽ༼ຈل͜ຈ༽ﾉ"
+
+        c.execute("SET standard_conforming_strings=0")  # to allow backslashes in bytea
 
         c.execute("INSERT INTO test_bytea_roundtrip VALUES (1, ?)", (Binary(data),))
         c.execute("SELECT b FROM test_bytea_roundtrip")

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -287,7 +287,8 @@ def test_parameterized_query(connection: Connection) -> None:
 
 
 def test_queries_fail_without_standard_strings(connection: Connection) -> None:
-    """Queries fail without standard_conforming_strings=0"""
+    """Queries fail without standard_conforming_strings=0
+    if this starts to fail, update bytea and \0 tests"""
     bytea_data = "bytea_123\n\tヽ༼ຈل͜ຈ༽ﾉ"
     with connection.cursor() as c:
         c.execute("DROP TABLE IF EXISTS test_fail_parametrized")

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -273,9 +273,6 @@ def test_parameterized_query(connection: Connection) -> None:
             params,
         )
 
-        # \0 is converted to 0
-        params[2] = "text0"
-
         assert (
             c.execute("SELECT * FROM test_tb_parameterized") == 1
         ), "Invalid data length in table after parameterized insert"
@@ -499,6 +496,8 @@ def test_bytea_roundtrip(
         )
 
         data = "bytea_123\n\tヽ༼ຈل͜ຈ༽ﾉ"
+
+        c.execute("SET standard_conforming_strings=0")  # to allow backslashes in bytea
 
         c.execute("INSERT INTO test_bytea_roundtrip VALUES (1, ?)", (Binary(data),))
         c.execute("SELECT b FROM test_bytea_roundtrip")


### PR DESCRIPTION
Query backend has changed, applying changes to keep the tests running.
This functionality is controlled by a feature flag that support will use while rolling it out.