### PR TITLE
chore: Standardise line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Let git handle line endings
+* text=auto


### PR DESCRIPTION
This setting automatically instructs Git to convert your local line endings to the ones of the repo on commit. This allows us to concentrate on actual changes to the files even if contributors work on Windows systems.
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings