### PR TITLE
chore: Update alter database syntax

### DIFF
--- a/src/firebolt/model/V2/database.py
+++ b/src/firebolt/model/V2/database.py
@@ -25,7 +25,7 @@ class Database(FireboltBaseModel):
     but otherwise are not configurable.
     """
 
-    ALTER_SQL: ClassVar[str] = "ALTER DATABASE {} WITH DESCRIPTION = ?"
+    ALTER_SQL: ClassVar[str] = "ALTER DATABASE {} SET DESCRIPTION = ?"
 
     DROP_SQL: ClassVar[str] = "DROP DATABASE {}"
 


### PR DESCRIPTION
FIR-30871

`ALTER DATABASE x WITH` has been changed to `ALTER DATABASE x SET`
Reflecting this in code and adding missing tests.