### PR TITLE
test: Increase long test execution

### DIFF
--- a/tests/integration/dbapi/async/V2/test_queries_async.py
+++ b/tests/integration/dbapi/async/V2/test_queries_async.py
@@ -134,7 +134,7 @@ async def test_long_query(
 
     with connection.cursor() as c:
         await c.execute(
-            "SELECT checksum(*) FROM GENERATE_SERIES(1, 200000000000)",  # approx 6m runtime
+            "SELECT checksum(*) FROM GENERATE_SERIES(1, 400000000000)",  # approx 6m runtime
         )
         data = await c.fetchall()
         assert len(data) == 1, "Invalid data size returned by fetchall"

--- a/tests/integration/dbapi/sync/V2/test_queries.py
+++ b/tests/integration/dbapi/sync/V2/test_queries.py
@@ -138,7 +138,7 @@ def test_long_query(
 
     with connection.cursor() as c:
         c.execute(
-            "SELECT checksum(*) FROM GENERATE_SERIES(1, 200000000000)",  # approx 6m runtime
+            "SELECT checksum(*) FROM GENERATE_SERIES(1, 400000000000)",  # approx 6m runtime
         )
         data = c.fetchall()
         assert len(data) == 1, "Invalid data size returned by fetchall"


### PR DESCRIPTION
As Firebolt has improved our "long" tests became too fast. Making them slower so they test the timeout again.