### PR TITLE
test: Fix SA engine check

### DIFF
--- a/tests/integration/dbapi/async/V2/conftest.py
+++ b/tests/integration/dbapi/async/V2/conftest.py
@@ -124,7 +124,7 @@ async def service_account_no_user(
     with connection_system_engine_no_db.cursor() as cursor:
         await cursor.execute(
             f'CREATE SERVICE ACCOUNT "{sa_account_name}" '
-            'WITH DESCRIPTION = "Ecosytem test with no user"'
+            "WITH DESCRIPTION = 'Ecosytem test with no user'"
         )
         await cursor.execute(f"CALL fb_GENERATESERVICEACCOUNTKEY('{sa_account_name}')")
         # service_account_name, service_account_id, secret

--- a/tests/integration/dbapi/async/V2/test_system_engine_async.py
+++ b/tests/integration/dbapi/async/V2/test_system_engine_async.py
@@ -48,10 +48,9 @@ async def test_system_engine(
 
         if connection_system_engine.database:
             await c.execute("show tables")
-            await c.execute(
-                "create table if not exists test_async(id int) primary index id"
-            )
             with raises(OperationalError):
+                # Either one or another query fails if we're not on a user engine
+                await c.execute("create table if not exists test_async(id int)")
                 await c.execute("insert into test values (1)")
         else:
             await c.execute("show databases")

--- a/tests/integration/dbapi/async/V2/test_system_engine_async.py
+++ b/tests/integration/dbapi/async/V2/test_system_engine_async.py
@@ -51,7 +51,7 @@ async def test_system_engine(
             with raises(OperationalError):
                 # Either one or another query fails if we're not on a user engine
                 await c.execute("create table if not exists test_async(id int)")
-                await c.execute("insert into test values (1)")
+                await c.execute("insert into test_async values (1)")
         else:
             await c.execute("show databases")
             with raises(OperationalError):

--- a/tests/integration/dbapi/sync/V2/test_system_engine.py
+++ b/tests/integration/dbapi/sync/V2/test_system_engine.py
@@ -48,8 +48,9 @@ def test_system_engine(
 
         if connection_system_engine.database:
             c.execute("show tables")
-            c.execute("create table if not exists test_sync(id int) primary index id")
             with raises(OperationalError):
+                # Either one or another query fails if we're not on a user engine
+                c.execute("create table if not exists test_sync(id int)")
                 c.execute("insert into test values (1)")
         else:
             c.execute("show databases")

--- a/tests/integration/dbapi/sync/V2/test_system_engine.py
+++ b/tests/integration/dbapi/sync/V2/test_system_engine.py
@@ -1,3 +1,4 @@
+import re
 from typing import List
 
 from pytest import raises
@@ -6,6 +7,10 @@ from firebolt.common._types import ColType, Column
 from firebolt.db import Connection
 from firebolt.utils.exception import OperationalError
 from tests.integration.dbapi.utils import assert_deep_eq
+
+system_error_pattern = re.compile(
+    r"system engine doesn't support .* statements. Run this statement on a user engine."
+)
 
 
 def test_system_engine(
@@ -48,10 +53,11 @@ def test_system_engine(
 
         if connection_system_engine.database:
             c.execute("show tables")
-            with raises(OperationalError):
+            with raises(OperationalError) as e:
                 # Either one or another query fails if we're not on a user engine
                 c.execute("create table if not exists test_sync(id int)")
                 c.execute("insert into test_sync values (1)")
+            assert system_error_pattern.search(str(e.value)), "Invalid error message"
         else:
             c.execute("show databases")
             with raises(OperationalError):

--- a/tests/integration/dbapi/sync/V2/test_system_engine.py
+++ b/tests/integration/dbapi/sync/V2/test_system_engine.py
@@ -51,7 +51,7 @@ def test_system_engine(
             with raises(OperationalError):
                 # Either one or another query fails if we're not on a user engine
                 c.execute("create table if not exists test_sync(id int)")
-                c.execute("insert into test values (1)")
+                c.execute("insert into test_sync values (1)")
         else:
             c.execute("show databases")
             with raises(OperationalError):


### PR DESCRIPTION
CREATE TABLE works on FB 1.0 and 2.0 engines v2, but not on 2.0 engines v2.
Either way we'll fail on CREATE or INSERT statement when running on system engine so I'm modifying the test to reflect that.

Also fixing DESCRIPTION clause in fixture.