### PR TITLE
test: Skip databases get_many

### DIFF
--- a/tests/integration/resource_manager/V2/test_database.py
+++ b/tests/integration/resource_manager/V2/test_database.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 from firebolt.client.auth import Auth
 from firebolt.service.manager import ResourceManager
 
@@ -33,6 +35,7 @@ def test_database_get_default_engine(
     ], "Returned default engine name is neither of known engines"
 
 
+@mark.skip("split is not supported in engines v1 right now")
 def test_databases_get_many(
     auth: Auth,
     account_name: str,

--- a/tests/integration/resource_manager/V2/test_database.py
+++ b/tests/integration/resource_manager/V2/test_database.py
@@ -35,7 +35,7 @@ def test_database_get_default_engine(
     ], "Returned default engine name is neither of known engines"
 
 
-@mark.skip("FIR-32303. Split is not supported in engines v1 right now")
+@mark.skip("FIR-32303. Split is not supported in engines v1 right now.")
 def test_databases_get_many(
     auth: Auth,
     account_name: str,

--- a/tests/integration/resource_manager/V2/test_database.py
+++ b/tests/integration/resource_manager/V2/test_database.py
@@ -35,7 +35,7 @@ def test_database_get_default_engine(
     ], "Returned default engine name is neither of known engines"
 
 
-@mark.skip("split is not supported in engines v1 right now")
+@mark.skip("FIR-32303. Split is not supported in engines v1 right now")
 def test_databases_get_many(
     auth: Auth,
     account_name: str,


### PR DESCRIPTION
This test is temporarily skipped since the underlying function is disabled in engines v1. Will revisit this later.