### PR TITLE
fix: Readd get_many for old engines

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ ciso8601 =
 dev =
     allure-pytest==2.*
     devtools==0.7.0
-    mypy==1.*
+    mypy==1.*,<1.10.0
     pre-commit==2.15.0
     pyfakefs>=4.5.3
     pytest==7.2.0

--- a/tests/integration/resource_manager/V1/test_engine.py
+++ b/tests/integration/resource_manager/V1/test_engine.py
@@ -16,6 +16,11 @@ def test_get_engine(resource_manager: ResourceManager, engine_name: str):
     )
 
 
+def test_get_many(resource_manager: ResourceManager, engine_name: str):
+    engines = resource_manager.engines.get_many(name_contains=engine_name)
+    assert len(engines) == 1
+
+
 @mark.skip(reason="Interferes with other tests")
 def test_engine_stop_start(resource_manager: ResourceManager, engine_name: str):
     engine = resource_manager.engines.get_by_name(engine_name)

--- a/tests/integration/resource_manager/V1/test_engine.py
+++ b/tests/integration/resource_manager/V1/test_engine.py
@@ -18,7 +18,8 @@ def test_get_engine(resource_manager: ResourceManager, engine_name: str):
 
 def test_get_many(resource_manager: ResourceManager, engine_name: str):
     engines = resource_manager.engines.get_many(name_contains=engine_name)
-    assert len(engines) == 1
+    # >= 1 because we may have a stopped engine with the same name + _stopped
+    assert len(engines) >= 1
 
 
 @mark.skip(reason="Interferes with other tests")

--- a/tests/unit/service/V1/conftest.py
+++ b/tests/unit/service/V1/conftest.py
@@ -261,6 +261,20 @@ def account_engine_callback(account_engine_url: str, mock_engine) -> Callable:
 
 
 @fixture
+def many_engines_callback(mock_engine: Engine) -> Callable:
+    def do_mock(
+        request: httpx.Request = None,
+        **kwargs,
+    ) -> Response:
+        return Response(
+            status_code=httpx.codes.OK,
+            json={"edges": [{"node": mock_engine.model_dict()}]},
+        )
+
+    return do_mock
+
+
+@fixture
 def account_engine_url(server: str, account_id, mock_engine) -> str:
     return f"https://{server}" + ACCOUNT_ENGINE_URL.format(
         account_id=account_id,

--- a/tests/unit/service/V1/test_engine.py
+++ b/tests/unit/service/V1/test_engine.py
@@ -24,7 +24,6 @@ def test_engine_start_stop(
     httpx_mock.add_callback(auth_callback, url=auth_url)
     httpx_mock.add_callback(provider_callback, url=provider_url)
     httpx_mock.add_callback(account_id_callback, url=account_id_url)
-    httpx_mock.add_callback(auth_callback, url=auth_url)
 
     httpx_mock.add_callback(engine_callback, url=f"{account_engine_url}", method="GET")
     httpx_mock.add_callback(
@@ -44,3 +43,58 @@ def test_engine_start_stop(
     engine = mock_engine.stop(wait_for_stop=False)
 
     assert engine.name == mock_engine.name
+
+
+def test_engine_get_many(
+    httpx_mock: HTTPXMock,
+    settings: Settings,
+    mock_engine: Engine,
+    auth_callback: Callable,
+    auth_url: str,
+    engine_url: str,
+    many_engines_callback: Callable,
+    provider_callback: Callable,
+    provider_url: str,
+    account_id_callback: Callable,
+    account_id_url: Pattern,
+):
+
+    httpx_mock.add_callback(auth_callback, url=auth_url)
+    httpx_mock.add_callback(provider_callback, url=provider_url)
+    httpx_mock.add_callback(account_id_callback, url=account_id_url)
+    filters = "?page.first=5000&filter.name_contains=test"
+    httpx_mock.add_callback(many_engines_callback, url=engine_url + filters)
+
+    manager = ResourceManager(settings=settings)
+    engines = manager.engines.get_many(name_contains="test")
+    assert len(engines) == 1
+    assert engines[0].name == mock_engine.name
+
+
+def test_engine_get_many_with_region(
+    httpx_mock: HTTPXMock,
+    settings: Settings,
+    mock_engine: Engine,
+    auth_callback: Callable,
+    auth_url: str,
+    engine_url: str,
+    many_engines_callback: Callable,
+    provider_callback: Callable,
+    provider_url: str,
+    account_id_callback: Callable,
+    account_id_url: Pattern,
+    region_callback: Callable,
+    region_url: str,
+):
+
+    httpx_mock.add_callback(auth_callback, url=auth_url)
+    httpx_mock.add_callback(provider_callback, url=provider_url)
+    httpx_mock.add_callback(account_id_callback, url=account_id_url)
+    httpx_mock.add_callback(region_callback, url=region_url)
+    filters = "?page.first=5000&filter.name_contains=test&filter.compute_region_id_region_id_eq=mock_region_id_1"
+    httpx_mock.add_callback(many_engines_callback, url=engine_url + filters)
+
+    manager = ResourceManager(settings=settings)
+    engines = manager.engines.get_many(name_contains="test", region_eq="mock_region_1")
+    assert len(engines) == 1
+    assert engines[0].name == mock_engine.name


### PR DESCRIPTION
get_many is missing since the version merge. Adding it as there might still be some use cases that rely on this.
Docs also mention this function.

Setting mypy to < 1.10.0 since the new version introduces errors outside of the scope of this change.