### PR TITLE
ci: Decrease engine name length

### DIFF
--- a/tests/integration/resource_manager/V2/conftest.py
+++ b/tests/integration/resource_manager/V2/conftest.py
@@ -3,12 +3,12 @@ from pytest import fixture
 
 @fixture
 def multi_param_engine_name(database_name: str) -> str:
-    return f"{database_name}_multi_param"
+    return f"{database_name}_m_param"
 
 
 @fixture
 def single_param_engine_name(database_name: str) -> str:
-    return f"{database_name}_single_param"
+    return f"{database_name}_s_param"
 
 
 @fixture


### PR DESCRIPTION
During nightlies some of the engine names became to long (>61 characters). This change avoids appending too much at the end.
e.g. https://github.com/firebolt-db/firebolt-python-sdk/actions/runs/8826365388/job/24231982381