### PR TITLE
build: lower limit httpcore to a stable version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     async-generator>=1.10
     async-property>=0.2.1
     cryptography>=3.4.0
+    httpcore>=0.17.0
     httpx[http2]>=0.19.0
     pydantic[dotenv]>=1.8.2,<3.0.0
     python-dateutil>=2.8.2


### PR DESCRIPTION
We recently an issue where running many async queries at the same time would cause a DNS resolution error. This was specifically due to a thread used by one of the dependencies being overloaded.
Upgrading httpcore seems to solve this so increasing the lower limit for it in our setup.cfg.