### PR TITLE
test: Fix service account deletion

### DIFF
--- a/tests/integration/dbapi/async/V2/conftest.py
+++ b/tests/integration/dbapi/async/V2/conftest.py
@@ -141,7 +141,7 @@ async def service_account_no_user(
             s_id = (await cursor.fetchone())[0]
         # Wrap in secret to avoid leaking the key in the logs
         yield s_id, Secret(key)
-        await cursor.execute(f"DROP SERVICE ACCOUNT {sa_account_name}")
+        await cursor.execute(f'DROP SERVICE ACCOUNT "{sa_account_name}"')
 
 
 @fixture

--- a/tests/integration/dbapi/sync/V2/conftest.py
+++ b/tests/integration/dbapi/sync/V2/conftest.py
@@ -141,7 +141,7 @@ def service_account_no_user(
             s_id = cursor.fetchone()[0]
         # Wrap in secret to avoid leaking the key in the logs
         yield s_id, Secret(key)
-        cursor.execute(f"DROP SERVICE ACCOUNT {sa_account_name}")
+        cursor.execute(f'DROP SERVICE ACCOUNT "{sa_account_name}"')
 
 
 @fixture


### PR DESCRIPTION
Since service account can be upper case we should quote it. It's unquoted in destruction SQL so it was erroring our integration tests/nightlies.