### PR TITLE
fix(FIR-34234): windows-compatible url parsing

### DIFF
--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -381,7 +381,7 @@ class CursorV2(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return await self._client.request(
-            url=os.path.join(self.engine_url, path or ""),
+            url=os.path.join(self.engine_url, os.sep, path or ""),
             method="POST",
             params=parameters,
             content=query,
@@ -451,7 +451,7 @@ class CursorV1(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return await self._client.request(
-            url=os.path.join(self.engine_url, path or ""),
+            url=os.path.join(self.engine_url, os.sep, path or ""),
             method="POST",
             params={
                 **(parameters or dict()),

--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from abc import ABCMeta, abstractmethod
 from functools import wraps
@@ -16,6 +15,7 @@ from typing import (
     Tuple,
     Union,
 )
+from urllib.parse import urljoin
 
 from httpx import URL, Headers, Response, codes
 
@@ -381,7 +381,7 @@ class CursorV2(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return await self._client.request(
-            url=os.path.join(self.engine_url, os.sep, path or ""),
+            url=urljoin(self.engine_url.rstrip("/") + "/", path or ""),
             method="POST",
             params=parameters,
             content=query,
@@ -451,7 +451,7 @@ class CursorV1(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return await self._client.request(
-            url=os.path.join(self.engine_url, os.sep, path or ""),
+            url=urljoin(self.engine_url.rstrip("/") + "/", path or ""),
             method="POST",
             params={
                 **(parameters or dict()),

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from abc import ABCMeta, abstractmethod
 from typing import (
@@ -14,6 +13,7 @@ from typing import (
     Tuple,
     Union,
 )
+from urllib.parse import urljoin
 
 from httpx import URL, Headers, Response, codes
 
@@ -331,7 +331,7 @@ class CursorV2(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return self._client.request(
-            url=os.path.join(self.engine_url, os.sep, path or ""),
+            url=urljoin(self.engine_url.rstrip("/") + "/", path or ""),
             method="POST",
             params=parameters,
             content=query,
@@ -398,7 +398,7 @@ class CursorV1(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return self._client.request(
-            url=os.path.join(self.engine_url, os.sep, path or ""),
+            url=urljoin(self.engine_url.rstrip("/") + "/", path or ""),
             method="POST",
             params={
                 **(parameters or dict()),

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -331,7 +331,7 @@ class CursorV2(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return self._client.request(
-            url=os.path.join(self.engine_url, path or ""),
+            url=os.path.join(self.engine_url, os.sep, path or ""),
             method="POST",
             params=parameters,
             content=query,
@@ -398,7 +398,7 @@ class CursorV1(Cursor):
         if self.parameters:
             parameters = {**self.parameters, **parameters}
         return self._client.request(
-            url=os.path.join(self.engine_url, path or ""),
+            url=os.path.join(self.engine_url, os.sep, path or ""),
             method="POST",
             params={
                 **(parameters or dict()),

--- a/tests/unit/common/test_token_storage.py
+++ b/tests/unit/common/test_token_storage.py
@@ -99,11 +99,9 @@ def test_token_storage_json_broken(fs: FakeFilesystem):
     """
     settings = {"username": "username", "password": "password"}
 
-    data_dir = os.path.join(user_config_dir(), os.sep, "firebolt")
+    data_dir = os.path.join(user_config_dir(), "firebolt")
     fs.create_dir(data_dir)
-    fs.create_file(
-        os.path.join(data_dir, os.sep, "token.json"), contents="{Not a valid json"
-    )
+    fs.create_file(os.path.join(data_dir, "token.json"), contents="{Not a valid json")
 
     assert TokenSecureStorage(**settings).get_cached_token() is None
 

--- a/tests/unit/common/test_token_storage.py
+++ b/tests/unit/common/test_token_storage.py
@@ -99,9 +99,11 @@ def test_token_storage_json_broken(fs: FakeFilesystem):
     """
     settings = {"username": "username", "password": "password"}
 
-    data_dir = os.path.join(user_config_dir(), "firebolt")
+    data_dir = os.path.join(user_config_dir(), os.sep, "firebolt")
     fs.create_dir(data_dir)
-    fs.create_file(os.path.join(data_dir, "token.json"), contents="{Not a valid json")
+    fs.create_file(
+        os.path.join(data_dir, os.sep, "token.json"), contents="{Not a valid json"
+    )
 
     assert TokenSecureStorage(**settings).get_cached_token() is None
 


### PR DESCRIPTION
os.path was not a good idea since on windows it uses different slashes. As I understand it's primary use is to resolve system paths instead of URL. 
Changed to urljoin, which seems to be the recommended solution. Test run [succeeds](https://github.com/firebolt-db/firebolt-python-sdk/actions/runs/9811623994).
The "/" trick we're doing is necessary at least to be compatible with the previous code. Our tests expect the url to have the trailing slash even if there's nothing after it (or just query parameters).