### PR TITLE
ci: Allow calling tests from another repo

### DIFF
--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          repository: 'firebolt-db/firebolt-python-sdk'
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -69,7 +69,7 @@ jobs:
             path: gh-pages
 
       - name: Allure Report
-        uses: firebolt-db/action-allure-report@add-decoration
+        uses: firebolt-db/action-allure-report@v1
         if: always()
         with:
           github-key: ${{ inputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ''
+      token:
+        description: 'GitHub token if called from another workflow'
+        required: false
+        type: string
 
 jobs:
   tests:
@@ -68,7 +72,7 @@ jobs:
         uses: firebolt-db/action-allure-report@add-decoration
         if: always()
         with:
-          github-key: ${{ secrets.GITHUB_TOKEN }}
+          github-key: ${{ inputs.token || secrets.GITHUB_TOKEN }}
           test-type: integration
           allure-dir: allure-results
           pages-branch: gh-pages

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -76,3 +76,4 @@ jobs:
           test-type: integration
           allure-dir: allure-results
           pages-branch: gh-pages
+          repository-name: python-sdk

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Need to pull the pages branch in order to fetch the previous runs
       - name: Get Allure history
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -65,7 +65,7 @@ jobs:
             path: gh-pages
 
       - name: Allure Report
-        uses: firebolt-db/action-allure-report@v1
+        uses: firebolt-db/action-allure-report@add-decoration
         if: always()
         with:
           github-key: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -7,6 +7,12 @@ on:
         required: true
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
         required: true
+    inputs:
+      engine-version:
+        description: 'Engine version to use for integration tests'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   tests:
@@ -35,6 +41,7 @@ jobs:
           firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
           account: ${{ vars.FIREBOLT_ACCOUNT }}
           api-endpoint: "api.staging.firebolt.io"
+          engine-version: ${{ inputs.engine-version }}
 
       - name: Run integration tests
         env:


### PR DESCRIPTION
This lets us run centralised tests from the ecosystem CI repo.