### PR TITLE
docs: remove outdated async execution section

### DIFF
--- a/docsrc/Connecting_and_queries.rst
+++ b/docsrc/Connecting_and_queries.rst
@@ -593,23 +593,6 @@ load on both server and client machines can be controlled. A suggested way is to
 
     run(run_multiple_queries())
 
-.. _Server-side async:
-
-Server-side asynchronous query execution
-==========================================
-
-In addition to :ref:`asynchronous API calls <firebolt.async_db:async db>`, which allow `client-side`
-execution to continue while waiting for API responses, the Python SDK provides `server-side`
-asynchronous query execution. When a query is executed asynchronously the only response
-from the server is a query ID. The status of the query can then be retrieved by polling
-the server at a later point. This frees the connection to do other queries or even be
-closed while the query continues to run. And entire service, such as AWS Lamdba, could
-potentially even be spun down an entire while a long-running database job is still underway.
-
-Note, however, that it is not possible to retrieve the results of a server-side asynchronous
-query, so these queries are best used for running DMLs and DDLs and ``SELECT``\ s should be used
-only for warming the cache.
-
 
 Thread safety
 ==============================


### PR DESCRIPTION
Removed server side async execution section, which is outdated for fb2.0