### PR TITLE
docs: Missing comma in connection example using dotenv

### DIFF
--- a/docsrc/Connecting_and_queries.rst
+++ b/docsrc/Connecting_and_queries.rst
@@ -113,7 +113,7 @@ To get started, follow the steps below:
                     auth=ClientCredentials(
                         os.getenv("FIREBOLT_CLIENT_ID"),
                         os.getenv("FIREBOLT_CLIENT_SECRET")
-                    )
+                    ),
                     engine_name=os.getenv('FIREBOLT_ENGINE'),
                     database=os.getenv('FIREBOLT_DB'),
                     account_name=os.getenv('FIREBOLT_ACCOUNT'),


### PR DESCRIPTION
Fails w/o comma in testing
<img width="801" alt="image" src="https://github.com/user-attachments/assets/11e5a885-8f8d-4f86-be7e-4502b9dc55bf">
