### PR TITLE
chore: Fix doc link in readme

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -67,5 +67,5 @@ jobs:
     - name: Add URL to the Job Summary
       shell: bash
       run: |
-        url="https://docs.firebolt.io/firebolt-python-sdk/sdk_documenation/${{ steps.resolve_url_path.outputs.path }}"
+        url="https://old.docs.firebolt.io/firebolt-python-sdk/sdk_documenation/${{ steps.resolve_url_path.outputs.path }}"
         echo "[Documentation]($url)" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Documentation
 
-For reference and tutorials, see the [Firebolt Python SDK reference](https://python-sdk.docs.firebolt.io/).
+For reference and tutorials, see the [Firebolt Python SDK reference](https://old.docs.firebolt.io/firebolt-python-sdk/sdk_documenation/latest/).
 
 ## Connection parameters
 These parameters are used to connect to a Firebolt database:


### PR DESCRIPTION
`python-sdk.docs.firebolt.io` is hosted on readthedocs, which we're not using anymore as it's not being rebuilt. Currently the docs are auto deployed at `old.docs.firebolt.io` due to the org rules. We'll change this separately.