### PR TITLE
fix: Fir 38125 ecosystem support for struct type for python sdk

### DIFF
--- a/tests/unit/common/test_typing_parse.py
+++ b/tests/unit/common/test_typing_parse.py
@@ -370,9 +370,9 @@ def test_parse_value_struct(value, expected, type_, error) -> None:
 @mark.parametrize(
     "value,expected",
     [
-        ("a int, b text", ["a int", " b text"]),
-        ("a int, s struct(a int, b text)", ["a int", " s struct(a int, b text)"]),
-        ("a int, b array(struct(a int))", ["a int", " b array(struct(a int))"]),
+        ("a int, b text", ["a int", "b text"]),
+        ("a int, s struct(a int, b text)", ["a int", "s struct(a int, b text)"]),
+        ("a int, b array(struct(a int))", ["a int", "b array(struct(a int))"]),
     ],
 )
 def test_split_struct_fields(value, expected) -> None:

--- a/tests/unit/common/test_typing_parse.py
+++ b/tests/unit/common/test_typing_parse.py
@@ -35,6 +35,13 @@ def test_parse_type(types_map: Dict[str, type]) -> None:
     ), "Invalid type parsing error message"
 
 
+def test_parse_struct_type_with_spaces() -> None:
+    parsed = parse_type("struct(`a b` int, s struct(`c d` text))")
+    assert parsed == STRUCT(
+        {"a b": int, "s": STRUCT({"c d": str})}
+    ), f"Error parsing struct type with spaces"
+
+
 @mark.parametrize(
     "value,expected,error",
     [


### PR DESCRIPTION
Fixed support for column names with spaces in structs