### PR TITLE
fix: Expose extended type via standard dbapi import

### DIFF
--- a/src/firebolt/async_db/__init__.py
+++ b/src/firebolt/async_db/__init__.py
@@ -12,6 +12,7 @@ from firebolt.common._types import (
     Binary,
     Date,
     DateFromTicks,
+    ExtendedType,
     Time,
     TimeFromTicks,
     Timestamp,

--- a/src/firebolt/db/__init__.py
+++ b/src/firebolt/db/__init__.py
@@ -10,6 +10,7 @@ from firebolt.common._types import (
     Binary,
     Date,
     DateFromTicks,
+    ExtendedType,
     Time,
     TimeFromTicks,
     Timestamp,


### PR DESCRIPTION
When using Array with typehints we run into mypy issues since ExtendedType is larger than a subset of it. e.g. a connector that does not yet have support for struct tries to define array element typehint as Union[type, Decimal, Array] but receives an error since it's actually an Extended type.