### PR TITLE
docs: remove docs repetition

### DIFF
--- a/docsrc/Connecting_and_queries.rst
+++ b/docsrc/Connecting_and_queries.rst
@@ -224,11 +224,6 @@ below use the data queried from ``test_table`` created in the
 
 	**Returns**: ``[[2, 'world'], [1, 'hello'], [3, '!']]``
 
-	::
-
-		print(cursor.fetchall())
-
-	**Returns**: ``[[2, 'world'], [1, 'hello'], [3, '!']]``
 
 Fetching query result information
 -----------------------


### PR DESCRIPTION
cursor.fetchall() example was written twice in docs