### PR TITLE
ci(NoTicket): Fix pre commit

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -30,4 +30,4 @@ jobs:
         pip install ".[dev]"
 
     - name: Run pre-commit checks
-      uses: pre-commit/action@v3.0.1
+      run: pre-commit run --all-files

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
     
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     


### PR DESCRIPTION
Pre-commit is using deprecated caching action and that action is no longer maintained. Instead a simple run command is used to run pre-commit checks.
Example [failure](https://github.com/firebolt-db/firebolt-python-sdk/actions/runs/14528967276/job/40783760962).