### PR TITLE
fix(NoTicket): Decimal parsing from float

### DIFF
--- a/src/firebolt/common/_types.py
+++ b/src/firebolt/common/_types.py
@@ -343,6 +343,10 @@ def parse_value(
     if isinstance(ctype, DECIMAL):
         if not isinstance(value, (str, int, float)):
             raise DataError(f"Invalid decimal value {value}: str or int expected")
+        if isinstance(value, float):
+            # Decimal constructor doesn't support float
+            # so we need to convert it to string first
+            value = str(value)
         return Decimal(value)
     if isinstance(ctype, ARRAY):
         if not isinstance(value, list):

--- a/tests/unit/common/test_typing_parse.py
+++ b/tests/unit/common/test_typing_parse.py
@@ -219,6 +219,7 @@ def test_parse_value_datetime_errors() -> None:
     [
         ("123.456", Decimal("123.456")),
         (123, Decimal("123")),
+        (123.456, Decimal("123.456")),
         (None, None),
     ],
 )

--- a/tests/unit/common/test_typing_parse.py
+++ b/tests/unit/common/test_typing_parse.py
@@ -226,7 +226,7 @@ def test_parse_value_datetime_errors() -> None:
 def test_parse_decimal(value, expected) -> None:
     assert (
         parse_value(value, DECIMAL(38, 3)) == expected
-    ), "Error parsing decimal(38, 3): provided {value}, expected {expected}"
+    ), f"Error parsing decimal(38, 3): provided {value}, expected {expected}"
 
 
 @mark.parametrize(


### PR DESCRIPTION
There's an issue exclusively for Firebolt 1.0 where decimal is returned as float, but we're parsing it incorrectly.
Parsing it into a string first keeps the correct precision.