### PR TITLE
fix(NoTicket): better decimal parsing and testing

### DIFF
--- a/src/firebolt/common/_types.py
+++ b/src/firebolt/common/_types.py
@@ -341,12 +341,8 @@ def parse_value(
             raise DataError(f"Invalid bytea value {value}: str expected")
         return _parse_bytea(value)
     if isinstance(ctype, DECIMAL):
-        if not isinstance(value, (str, int, float)):
+        if not isinstance(value, (str, int)):
             raise DataError(f"Invalid decimal value {value}: str or int expected")
-        if isinstance(value, float):
-            # Decimal constructor doesn't support float
-            # so we need to convert it to string first
-            value = str(value)
         return Decimal(value)
     if isinstance(ctype, ARRAY):
         if not isinstance(value, list):

--- a/src/firebolt/common/row_set/streaming_common.py
+++ b/src/firebolt/common/row_set/streaming_common.py
@@ -94,7 +94,8 @@ class StreamingRowSetCommonBase:
             return None
 
         try:
-            record = json.loads(next_line)
+            # Skip parsing floats to properly parse them later
+            record = json.loads(next_line, parse_float=str)
         except json.JSONDecodeError as err:
             raise OperationalError(
                 f"Invalid JSON line response format: {next_line}"

--- a/src/firebolt/common/row_set/synchronous/in_memory.py
+++ b/src/firebolt/common/row_set/synchronous/in_memory.py
@@ -43,7 +43,8 @@ class InMemoryRowSet(BaseSyncRowSet):
             self.append_empty_response()
         else:
             try:
-                query_data = json.loads(content)
+                # Skip parsing floats to properly parse them later
+                query_data = json.loads(content, parse_float=str)
 
                 if "errors" in query_data and len(query_data["errors"]) > 0:
                     raise FireboltStructuredError(query_data)

--- a/tests/integration/dbapi/async/V1/conftest.py
+++ b/tests/integration/dbapi/async/V1/conftest.py
@@ -1,11 +1,7 @@
-from decimal import Decimal
-from typing import List
-
 from pytest import fixture
 
 from firebolt.async_db import Connection, connect
 from firebolt.client.auth.base import Auth
-from firebolt.common._types import ColType
 
 
 @fixture
@@ -78,14 +74,3 @@ async def connection_no_engine(
         api_endpoint=api_endpoint,
     ) as connection:
         yield connection
-
-
-@fixture
-def all_types_query_response_v1(
-    all_types_query_response: List[List[ColType]],
-) -> List[List[ColType]]:
-    """
-    V1 still returns decimals as floats, despite overflow. That's why it's not fully accurate.
-    """
-    all_types_query_response[0][18] = Decimal("1231232.1234599999152123928070068359375")
-    return all_types_query_response

--- a/tests/integration/dbapi/async/V1/test_queries_async.py
+++ b/tests/integration/dbapi/async/V1/test_queries_async.py
@@ -78,7 +78,7 @@ async def test_connect_engine_name(
     connection_engine_name: Connection,
     all_types_query: str,
     all_types_query_description: List[Column],
-    all_types_query_response_v1: List[ColType],
+    all_types_query_response: List[ColType],
     timezone_name: str,
 ) -> None:
     """Connecting with engine name is handled properly."""
@@ -86,7 +86,7 @@ async def test_connect_engine_name(
         connection_engine_name,
         all_types_query,
         all_types_query_description,
-        all_types_query_response_v1,
+        all_types_query_response,
         timezone_name,
     )
 
@@ -95,7 +95,7 @@ async def test_connect_no_engine(
     connection_no_engine: Connection,
     all_types_query: str,
     all_types_query_description: List[Column],
-    all_types_query_response_v1: List[ColType],
+    all_types_query_response: List[ColType],
     timezone_name: str,
 ) -> None:
     """Connecting with engine name is handled properly."""
@@ -103,7 +103,7 @@ async def test_connect_no_engine(
         connection_no_engine,
         all_types_query,
         all_types_query_description,
-        all_types_query_response_v1,
+        all_types_query_response,
         timezone_name,
     )
 
@@ -112,7 +112,7 @@ async def test_select(
     connection: Connection,
     all_types_query: str,
     all_types_query_description: List[Column],
-    all_types_query_response_v1: List[ColType],
+    all_types_query_response: List[ColType],
     timezone_name: str,
 ) -> None:
     """Select handles all data types properly."""
@@ -130,7 +130,7 @@ async def test_select(
         assert c.rowcount == 1, "Invalid rowcount value"
         data = await c.fetchall()
         assert len(data) == c.rowcount, "Invalid data length"
-        assert_deep_eq(data, all_types_query_response_v1, "Invalid data")
+        assert_deep_eq(data, all_types_query_response, "Invalid data")
         assert c.description == all_types_query_description, "Invalid description value"
         assert len(data[0]) == len(c.description), "Invalid description length"
         assert len(await c.fetchall()) == 0, "Redundant data returned by fetchall"
@@ -138,7 +138,7 @@ async def test_select(
         # Different fetch types
         await c.execute(all_types_query)
         assert (
-            await c.fetchone() == all_types_query_response_v1[0]
+            await c.fetchone() == all_types_query_response[0]
         ), "Invalid fetchone data"
         assert await c.fetchone() is None, "Redundant data returned by fetchone"
 
@@ -147,7 +147,7 @@ async def test_select(
         data = await c.fetchmany()
         assert len(data) == 1, "Invalid data size returned by fetchmany"
         assert_deep_eq(
-            data, all_types_query_response_v1, "Invalid data returned by fetchmany"
+            data, all_types_query_response, "Invalid data returned by fetchmany"
         )
 
 
@@ -328,7 +328,7 @@ async def test_parameterized_query(connection: Connection) -> None:
             datetime(2022, 1, 1, 1, 1, 1),
             True,
             [1, 2, 3],
-            Decimal(123.456),
+            Decimal("123.456"),
         ]
 
         await test_empty_query(

--- a/tests/integration/dbapi/sync/V1/conftest.py
+++ b/tests/integration/dbapi/sync/V1/conftest.py
@@ -1,10 +1,6 @@
-from decimal import Decimal
-from typing import List
-
 from pytest import fixture
 
 from firebolt.client.auth.base import Auth
-from firebolt.common._types import ColType
 from firebolt.db import Connection, connect
 
 
@@ -97,14 +93,3 @@ def connection_system_engine(
     )
     yield connection
     connection.close()
-
-
-@fixture
-def all_types_query_response(
-    all_types_query_response: List[List[ColType]],
-) -> List[List[ColType]]:
-    """
-    V1 still returns decimals as floats, despite overflow. That's why it's not fully accurate.
-    """
-    all_types_query_response[0][18] = Decimal("1231232.1234599999152123928070068359375")
-    return all_types_query_response

--- a/tests/integration/dbapi/sync/V1/conftest.py
+++ b/tests/integration/dbapi/sync/V1/conftest.py
@@ -100,7 +100,7 @@ def connection_system_engine(
 
 
 @fixture
-def all_types_query_response_v1(
+def all_types_query_response(
     all_types_query_response: List[List[ColType]],
 ) -> List[List[ColType]]:
     """

--- a/tests/integration/dbapi/sync/V1/test_queries.py
+++ b/tests/integration/dbapi/sync/V1/test_queries.py
@@ -30,7 +30,7 @@ def test_connect_engine_name(
     connection_engine_name: Connection,
     all_types_query: str,
     all_types_query_description: List[Column],
-    all_types_query_response_v1: List[ColType],
+    all_types_query_response: List[ColType],
     timezone_name: str,
 ) -> None:
     """Connecting with engine name is handled properly."""
@@ -38,7 +38,7 @@ def test_connect_engine_name(
         connection_engine_name,
         all_types_query,
         all_types_query_description,
-        all_types_query_response_v1,
+        all_types_query_response,
         timezone_name,
     )
 
@@ -47,7 +47,7 @@ def test_connect_no_engine(
     connection_no_engine: Connection,
     all_types_query: str,
     all_types_query_description: List[Column],
-    all_types_query_response_v1: List[ColType],
+    all_types_query_response: List[ColType],
     timezone_name: str,
 ) -> None:
     """Connecting with engine name is handled properly."""
@@ -55,7 +55,7 @@ def test_connect_no_engine(
         connection_no_engine,
         all_types_query,
         all_types_query_description,
-        all_types_query_response_v1,
+        all_types_query_response,
         timezone_name,
     )
 
@@ -64,7 +64,7 @@ def test_select(
     connection: Connection,
     all_types_query: str,
     all_types_query_description: List[Column],
-    all_types_query_response_v1: List[ColType],
+    all_types_query_response: List[ColType],
     timezone_name: str,
 ) -> None:
     """Select handles all data types properly."""
@@ -82,14 +82,14 @@ def test_select(
         assert c.rowcount == 1, "Invalid rowcount value"
         data = c.fetchall()
         assert len(data) == c.rowcount, "Invalid data length"
-        assert_deep_eq(data, all_types_query_response_v1, "Invalid data")
+        assert_deep_eq(data, all_types_query_response, "Invalid data")
         assert c.description == all_types_query_description, "Invalid description value"
         assert len(data[0]) == len(c.description), "Invalid description length"
         assert len(c.fetchall()) == 0, "Redundant data returned by fetchall"
 
         # Different fetch types
         c.execute(all_types_query)
-        assert c.fetchone() == all_types_query_response_v1[0], "Invalid fetchone data"
+        assert c.fetchone() == all_types_query_response[0], "Invalid fetchone data"
         assert c.fetchone() is None, "Redundant data returned by fetchone"
 
         c.execute(all_types_query)
@@ -97,7 +97,7 @@ def test_select(
         data = c.fetchmany()
         assert len(data) == 1, "Invalid data size returned by fetchmany"
         assert_deep_eq(
-            data, all_types_query_response_v1, "Invalid data returned by fetchmany"
+            data, all_types_query_response, "Invalid data returned by fetchmany"
         )
 
 
@@ -273,7 +273,7 @@ def test_parameterized_query(connection: Connection) -> None:
             datetime(2022, 1, 1, 1, 1, 1),
             True,
             [1, 2, 3],
-            Decimal(123.456),
+            Decimal("123.456"),
         ]
 
         test_empty_query(

--- a/tests/unit/common/row_set/asynchronous/test_in_memory.py
+++ b/tests/unit/common/row_set/asynchronous/test_in_memory.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -173,6 +174,7 @@ class TestInMemoryAsyncRowSet:
 
     async def test_append_response(self, in_memory_rowset, mock_response):
         """Test appending a response with data."""
+
         # Create a proper aclose method
         async def mock_aclose():
             mock_response.is_closed = True
@@ -207,6 +209,7 @@ class TestInMemoryAsyncRowSet:
         self, in_memory_rowset, mock_empty_response
     ):
         """Test appending a response with empty content."""
+
         # Create a proper aclose method
         async def mock_aclose():
             mock_empty_response.is_closed = True
@@ -226,6 +229,7 @@ class TestInMemoryAsyncRowSet:
         self, in_memory_rowset, mock_invalid_json_response
     ):
         """Test appending a response with invalid JSON."""
+
         # Create a proper aclose method
         async def mock_aclose():
             mock_invalid_json_response.is_closed = True
@@ -245,6 +249,7 @@ class TestInMemoryAsyncRowSet:
         self, in_memory_rowset, mock_missing_meta_response
     ):
         """Test appending a response with missing meta field."""
+
         # Create a proper aclose method
         async def mock_aclose():
             mock_missing_meta_response.is_closed = True
@@ -264,6 +269,7 @@ class TestInMemoryAsyncRowSet:
         self, in_memory_rowset, mock_missing_data_response
     ):
         """Test appending a response with missing data field."""
+
         # Create a proper aclose method
         async def mock_aclose():
             mock_missing_data_response.is_closed = True
@@ -281,6 +287,7 @@ class TestInMemoryAsyncRowSet:
 
     async def test_nextset_no_more_sets(self, in_memory_rowset, mock_response):
         """Test nextset when there are no more result sets."""
+
         # Create a proper aclose method
         async def mock_aclose():
             pass
@@ -296,6 +303,7 @@ class TestInMemoryAsyncRowSet:
         The implementation seems to add rowsets correctly, but behaves differently
         than expected when accessing them via nextset.
         """
+
         # Create a proper aclose method
         async def mock_aclose():
             pass
@@ -322,6 +330,7 @@ class TestInMemoryAsyncRowSet:
 
     async def test_iteration(self, in_memory_rowset, mock_response):
         """Test row iteration."""
+
         # Create a proper aclose method
         async def mock_aclose():
             pass
@@ -347,6 +356,7 @@ class TestInMemoryAsyncRowSet:
         This test is tricky because in the mock setup, the second row set
         is actually empty despite us adding the same mock response.
         """
+
         # Create a proper aclose method
         async def mock_aclose():
             pass
@@ -410,6 +420,7 @@ class TestInMemoryAsyncRowSet:
 
     async def test_aclose(self, in_memory_rowset, mock_response):
         """Test aclose method."""
+
         # Create a proper aclose method
         async def mock_aclose():
             pass
@@ -423,3 +434,23 @@ class TestInMemoryAsyncRowSet:
 
             # Verify sync close was called
             mock_close.assert_called_once()
+
+    async def test_append_response_with_decimals(
+        self, in_memory_rowset: InMemoryAsyncRowSet, mock_decimal_bytes_stream: Response
+    ):
+
+        await in_memory_rowset.append_response(mock_decimal_bytes_stream)
+
+        # Verify basic properties
+        assert in_memory_rowset.row_count == 2
+        assert len(in_memory_rowset.columns) == 3
+
+        # Get the row values and check decimal values are equal
+        rows = [row async for row in in_memory_rowset]
+
+        # Verify the decimal value is correctly parsed
+        for row in rows:
+            assert isinstance(row[2], Decimal), "Expected Decimal type"
+            assert (
+                str(row[2]) == "1231232.123459999990457054844258706536"
+            ), "Decimal value mismatch"

--- a/tests/unit/common/row_set/conftest.py
+++ b/tests/unit/common/row_set/conftest.py
@@ -16,7 +16,7 @@ def mock_decimal_response_streaming() -> Response:
         "result_columns": [
             {"name": "col1", "type": "int"},
             {"name": "col2", "type": "string"},
-            {"name": "col3", "type": "Decimal(10, 2)"},
+            {"name": "col3", "type": "numeric(10, 2)"},
         ],
         "query_id": "q1",
         "query_label": "l1",

--- a/tests/unit/common/row_set/conftest.py
+++ b/tests/unit/common/row_set/conftest.py
@@ -1,0 +1,117 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import Response
+
+
+@pytest.fixture
+def mock_decimal_response_streaming() -> Response:
+    """Create a mock Response with decimal data."""
+    mock = MagicMock(spec=Response)
+
+    # Create JSON record strings with properly formatted data
+    start_record_data = {
+        "message_type": "START",
+        "result_columns": [
+            {"name": "col1", "type": "int"},
+            {"name": "col2", "type": "string"},
+            {"name": "col3", "type": "Decimal(10, 2)"},
+        ],
+        "query_id": "q1",
+        "query_label": "l1",
+        "request_id": "r1",
+    }
+
+    data_record_data = {
+        "message_type": "DATA",
+        "data": [
+            [1, "one", "1231232.123459999990457054844258706536"],
+            [2, "two", "1231232.123459999990457054844258706536"],
+        ],
+    }
+
+    success_record_data = {
+        "message_type": "FINISH_SUCCESSFULLY",
+        "statistics": {
+            "elapsed": 0.1,
+            "rows_read": 10,
+            "bytes_read": 100,
+            "time_before_execution": 0.01,
+            "time_to_execute": 0.09,
+        },
+    }
+
+    # Generate the JSON strings
+    start_record = json.dumps(start_record_data)
+    data_record = json.dumps(data_record_data)
+
+    # Replace the decimal string with a float to simulate the behavior of FB 1.0
+    # for one of the rows
+    data_record = data_record.replace(
+        '"1231232.123459999990457054844258706536"',
+        "1231232.123459999990457054844258706536",
+        1,
+    )
+
+    success_record = json.dumps(success_record_data)
+
+    mock.iter_lines.return_value = iter([start_record, data_record, success_record])
+
+    async def async_iter():
+        for item in [
+            start_record.encode("utf-8"),
+            data_record.encode("utf-8"),
+            success_record.encode("utf-8"),
+        ]:
+            yield item
+
+    mock.aiter_lines.side_effect = async_iter
+    mock.is_closed = False
+    return mock
+
+
+@pytest.fixture
+def mock_decimal_bytes_stream() -> Response:
+    """Create a mock bytes stream with decimal data."""
+    mock = MagicMock(spec=Response)
+    data = iter(
+        [
+            json.dumps(
+                {
+                    "meta": [
+                        {"name": "col1", "type": "int"},
+                        {"name": "col2", "type": "string"},
+                        {"name": "col3", "type": "Decimal(10, 2)"},
+                    ],
+                    "data": [
+                        [1, "one", "1231232.123459999990457054844258706536"],
+                        [2, "two", "1231232.123459999990457054844258706536"],
+                    ],
+                    "statistics": {
+                        "elapsed": 0.1,
+                        "rows_read": 10,
+                        "bytes_read": 100,
+                        "time_before_execution": 0.01,
+                        "time_to_execute": 0.09,
+                    },
+                }
+            )
+            # Replace the decimal string with a float to simulate the behavior of FB 1.0
+            # for one of the rows
+            .replace(
+                '"1231232.123459999990457054844258706536"',
+                "1231232.123459999990457054844258706536",
+                1,
+            ).encode("utf-8")
+        ]
+    )
+    mock.iter_bytes.return_value = data
+
+    async def async_iter():
+        for item in data:
+            yield item
+
+    mock.aiter_bytes.side_effect = async_iter
+    mock.is_closed = False
+    return mock

--- a/tests/unit/common/test_typing_parse.py
+++ b/tests/unit/common/test_typing_parse.py
@@ -219,7 +219,6 @@ def test_parse_value_datetime_errors() -> None:
     [
         ("123.456", Decimal("123.456")),
         (123, Decimal("123")),
-        (123.456, Decimal("123.456")),
         (None, None),
     ],
 )


### PR DESCRIPTION
Fixing decimal parsing again. `json.loads` does not parse decimal if it's not quoted, since it breaks JSON convention. The value returned is truncated. I'm porting back a fix we had before streaming that does not parse float on `json.loads` and lets the rest of the parsing code handle it.
A bunch of tests to verify this in different scenarios. 