### PR TITLE
Expose _get_async_query_info

### DIFF
--- a/src/firebolt/async_db/connection.py
+++ b/src/firebolt/async_db/connection.py
@@ -92,7 +92,7 @@ class Connection(BaseConnection):
         return c
 
     # Server-side async methods
-    async def _get_async_query_info(self, token: str) -> AsyncQueryInfo:
+    async def get_async_query_info(self, token: str) -> AsyncQueryInfo:
         if self.cursor_type != CursorV2:
             raise FireboltError(
                 "This method is only supported for connection with service account."
@@ -130,7 +130,7 @@ class Connection(BaseConnection):
         Returns:
             bool: True if async query is still running, False otherwise
         """
-        async_query_details = await self._get_async_query_info(token)
+        async_query_details = await self.get_async_query_info(token)
         return async_query_details.status == ASYNC_QUERY_STATUS_RUNNING
 
     async def is_async_query_successful(self, token: str) -> Optional[bool]:
@@ -144,7 +144,7 @@ class Connection(BaseConnection):
             bool: None if the query is still running, True if successful,
                   False otherwise
         """
-        async_query_details = await self._get_async_query_info(token)
+        async_query_details = await self.get_async_query_info(token)
         if async_query_details.status == ASYNC_QUERY_STATUS_RUNNING:
             return None
         return async_query_details.status == ASYNC_QUERY_STATUS_SUCCESSFUL
@@ -156,7 +156,7 @@ class Connection(BaseConnection):
         Args:
             token: Async query token. Can be obtained from Cursor.async_query_token.
         """
-        async_query_details = await self._get_async_query_info(token)
+        async_query_details = await self.get_async_query_info(token)
         async_query_id = async_query_details.query_id
         cursor = self.cursor()
         await cursor.execute(ASYNC_QUERY_CANCEL, [async_query_id])

--- a/src/firebolt/db/connection.py
+++ b/src/firebolt/db/connection.py
@@ -230,7 +230,7 @@ class Connection(BaseConnection):
 
     # Server-side async methods
 
-    def _get_async_query_info(self, token: str) -> AsyncQueryInfo:
+    def get_async_query_info(self, token: str) -> AsyncQueryInfo:
         if self.cursor_type != CursorV2:
             raise FireboltError(
                 "This method is only supported for connection with service account."
@@ -268,7 +268,7 @@ class Connection(BaseConnection):
         Returns:
             bool: True if async query is still running, False otherwise
         """
-        return self._get_async_query_info(token).status == ASYNC_QUERY_STATUS_RUNNING
+        return self.get_async_query_info(token).status == ASYNC_QUERY_STATUS_RUNNING
 
     def is_async_query_successful(self, token: str) -> Optional[bool]:
         """
@@ -281,7 +281,7 @@ class Connection(BaseConnection):
             bool: None if the query is still running, True if successful,
                   False otherwise
         """
-        async_query_info = self._get_async_query_info(token)
+        async_query_info = self.get_async_query_info(token)
         if async_query_info.status == ASYNC_QUERY_STATUS_RUNNING:
             return None
         return async_query_info.status == ASYNC_QUERY_STATUS_SUCCESSFUL
@@ -293,7 +293,7 @@ class Connection(BaseConnection):
         Args:
             token: Async query token. Can be obtained from Cursor.async_query_token.
         """
-        async_query_id = self._get_async_query_info(token).query_id
+        async_query_id = self.get_async_query_info(token).query_id
         cursor = self.cursor()
         cursor.execute(ASYNC_QUERY_CANCEL, [async_query_id])
 


### PR DESCRIPTION
It seems that `_get_async_query_info` can be really helpful for getting all the information about a running async query given a provided token.
Right now, it is only supported to either cancel a query or check if it finished or succeeded.
Getting more information about it like the `query_id` or `error_message` (if query failed) is necessary for easy monitoring/debugging purposes.