### PR TITLE
ci(NoTicket): Add core tests to nightlies

### DIFF
--- a/.github/workflows/integration-tests-core.yml
+++ b/.github/workflows/integration-tests-core.yml
@@ -68,6 +68,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
+      - name: Setup docker (missing on MacOS)
+        if: runner.os == 'macos'
+        run: |
+          brew install docker
+          colima start
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/integration-tests-core.yml
+++ b/.github/workflows/integration-tests-core.yml
@@ -72,7 +72,6 @@ jobs:
         if: runner.os == 'macos'
         run: |
           brew install docker
-          colima start
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/integration-tests-core.yml
+++ b/.github/workflows/integration-tests-core.yml
@@ -72,6 +72,8 @@ jobs:
         if: runner.os == 'macos'
         run: |
           brew install docker
+          brew install colima
+          colima start
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/integration-tests-core.yml
+++ b/.github/workflows/integration-tests-core.yml
@@ -68,13 +68,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]"
 
-      - name: Setup docker (missing on MacOS)
-        if: runner.os == 'macos'
-        run: |
-          brew install docker
-          brew install colima
-          colima start
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       fail-fast: false # finish all jobs even if one fails
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        # No windows support for core yet
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     uses: ./.github/workflows/integration-tests-core.yml
     with:
       os_name: ${{ matrix.os }}

--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -16,6 +16,17 @@ jobs:
     secrets:
       FOSSA_TOKEN: ${{ secrets.FOSSA_TOKEN }}
       SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+  core:
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10']
+    uses: ./.github/workflows/integration-tests-core.yml
+    with:
+      os_name: ${{ matrix.os }}
+      python_version: ${{ matrix.python-version }}
+      sendSlackNotifications: true
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,7 +76,7 @@ jobs:
           ACCOUNT_NAME: "firebolt"
           API_ENDPOINT: "api.staging.firebolt.io"
         run: |
-          pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=WARNING --junit-xml=report/junit.xml tests/integration -k "not V2"
+          pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=WARNING --junit-xml=report/junit.xml tests/integration -k "not V2 and not core"
 
       - name: Slack Notify of failure
         if: failure()

--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false # finish all jobs even if one fails
       matrix:
         # No windows support for core yet
-        os: [ubuntu-latest, macos-latest]
+        # Macos is missing docker support
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
     uses: ./.github/workflows/integration-tests-core.yml
     with:

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -16,6 +16,17 @@ jobs:
     secrets:
       FOSSA_TOKEN: ${{ secrets.FOSSA_TOKEN }}
       SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+  core:
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10']
+    uses: ./.github/workflows/integration-tests-core.yml
+    with:
+      os_name: ${{ matrix.os }}
+      python_version: ${{ matrix.python-version }}
+      sendSlackNotifications: true
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,7 +73,7 @@ jobs:
           ACCOUNT_NAME: ${{ vars.FIREBOLT_ACCOUNT }}
           API_ENDPOINT: "api.staging.firebolt.io"
         run: |
-          pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=WARNING --junit-xml=report/junit.xml tests/integration -k "not V1"
+          pytest --timeout_method "thread" -o log_cli=true -o log_cli_level=WARNING --junit-xml=report/junit.xml tests/integration -k "not V1 and not core"
 
       - name: Slack Notify of failure
         if: failure()

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       fail-fast: false # finish all jobs even if one fails
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        # No windows support for core yet
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     uses: ./.github/workflows/integration-tests-core.yml
     with:
       os_name: ${{ matrix.os }}

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false # finish all jobs even if one fails
       matrix:
         # No windows support for core yet
-        os: [ubuntu-latest, macos-latest]
+        # Macos is missing docker support
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
     uses: ./.github/workflows/integration-tests-core.yml
     with:


### PR DESCRIPTION
Fix nightlies regular tests to not run core tests and add core workflow call.

There's no windows image compiled so skipping it in the matrix.
MacOS does not have docker installed by default. Fixing this might take some effort so skipping it for now.