### PR TITLE
Make V1 nightlies generate a unique db name

### DIFF
--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -63,6 +63,7 @@ jobs:
           firebolt-password: ${{ secrets.FIREBOLT_STG_PASSWORD }}
           api-endpoint: "api.staging.firebolt.io"
           region: "us-east-1"
+          db_suffix: ${{ format('{0}_{1}', matrix.os, matrix.python-version) }}
 
       - name: Run integration tests
         env:


### PR DESCRIPTION
Updated v1 nightly job to include os name and python version into the database name