### PR TITLE
chore(NoTicket): Improve plaintext error handling

### DIFF
--- a/src/firebolt/utils/util.py
+++ b/src/firebolt/utils/util.py
@@ -19,6 +19,7 @@ from httpx import URL, Response, codes
 
 from firebolt.utils.exception import (
     ConfigurationError,
+    FireboltError,
     FireboltStructuredError,
 )
 
@@ -171,6 +172,10 @@ def raise_error_from_response(resp: Response) -> None:
         resp (Response): HTTP response
     """
     to_raise = None
+    # If error is Text - raise as is
+    if "text/plain" in resp.headers.get("Content-Type", ""):
+        raise FireboltError(resp.text)
+    # If error is Json - parse it and raise
     try:
         decoded = resp.json()
         if "errors" in decoded and len(decoded["errors"]) > 0:
@@ -186,6 +191,7 @@ def raise_error_from_response(resp: Response) -> None:
         raise to_raise
 
     # Raise status error if no error info was found in the body
+    # This error does not contain the response body
     resp.raise_for_status()
 
 

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -1505,3 +1505,26 @@ async def test_unsupported_paramstyle_raises(cursor: Cursor) -> None:
             await cursor.execute("SELECT 1")
     finally:
         db.paramstyle = original_paramstyle
+
+
+async def test_cursor_plaintext_error(
+    httpx_mock: HTTPXMock,
+    cursor: Cursor,
+    query_url: str,
+):
+    """Test handling of plaintext error responses from the server."""
+    httpx_mock.add_callback(
+        lambda *args, **kwargs: Response(
+            status_code=codes.NOT_FOUND,
+            text="Plaintext error message",
+            headers={"Content-Type": "text/plain"},
+        ),
+        url=query_url,
+    )
+    with raises(FireboltError) as excinfo:
+        await cursor.execute("select * from t")
+
+    assert cursor._state == CursorState.ERROR
+    assert "Plaintext error message" in str(
+        excinfo.value
+    ), "Invalid error message for plaintext error response"


### PR DESCRIPTION
We assumed all the errors that are not recognised by us will be sent in a structured format, with JSON.
However, doesn't look like it's always the case.
We should be able to gracefully handle plaintext errors as well.