### PR TITLE
fix: don't inherit query_label on validation queries (FB-626)

### DIFF
--- a/src/firebolt/async_db/cursor.py
+++ b/src/firebolt/async_db/cursor.py
@@ -12,7 +12,11 @@ from httpx import URL, USE_CLIENT_DEFAULT, Response, TimeoutException, codes
 
 from firebolt.client.client import AsyncClient, AsyncClientV1, AsyncClientV2
 from firebolt.common._types import ColType, ParameterType, SetParameter
-from firebolt.common.constants import JSON_OUTPUT_FORMAT, CursorState
+from firebolt.common.constants import (
+    JSON_OUTPUT_FORMAT,
+    SET_VALIDATION_DROP_PARAMETER_KEYS,
+    CursorState,
+)
 from firebolt.common.cursor.base_cursor import (
     BaseCursor,
     _raise_if_internal_set_parameter,
@@ -88,6 +92,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         path: str = "",
         use_set_parameters: bool = True,
         timeout: Optional[float] = None,
+        drop_parameter_keys: Optional[Sequence[str]] = None,
     ) -> Response:
         """
         Query API, return Response object.
@@ -104,12 +109,22 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
                 set parameters are sent. Setting this to False will allow
                 self._set_parameters to be ignored.
             timeout (Optional[float]): Request execution timeout in seconds
+            drop_parameter_keys: If non-empty, remove these keys from merged request
+                parameters unless the key appears in this call's ``parameters``
+                dict (the explicit overlay). Empty or omitted is a no-op.
         """
-        parameters = parameters or {}
+        explicit = parameters or {}
         if use_set_parameters:
-            parameters = {**(self._set_parameters or {}), **parameters}
+            parameters = {**(self._set_parameters or {}), **explicit}
+        else:
+            parameters = dict(explicit)
         if self.parameters:
             parameters = {**self.parameters, **parameters}
+        if drop_parameter_keys:
+            explicit_keys = explicit.keys()
+            for k in drop_parameter_keys:
+                if k not in explicit_keys:
+                    parameters.pop(k, None)
         try:
             req = self._client.build_request(
                 url=urljoin(self.engine_url.rstrip("/") + "/", path or ""),
@@ -150,7 +165,10 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         """Validate parameter by executing simple query with it."""
         _raise_if_internal_set_parameter(parameter)
         resp = await self._api_request(
-            "select 1", {parameter.name: parameter.value}, timeout=timeout
+            "select 1",
+            {parameter.name: parameter.value},
+            timeout=timeout,
+            drop_parameter_keys=SET_VALIDATION_DROP_PARAMETER_KEYS,
         )
         # Handle invalid set parameter
         if resp.status_code == codes.BAD_REQUEST:

--- a/src/firebolt/common/constants.py
+++ b/src/firebolt/common/constants.py
@@ -37,7 +37,8 @@ TRANSACTION_PARAMETER_LIST = [TRANSACTION_ID_SETTING, TRANSACTION_SEQUENCE_ID_SE
 # parameters that are set by the backend and should not be set by the user
 IMMUTABLE_PARAMETER_LIST = USE_PARAMETER_LIST + DISALLOWED_PARAMETER_LIST
 
-# Keys omitted from SET validation probe requests (SELECT 1); values still stored after success
+# Keys omitted from SET validation probe requests (SELECT 1).
+# Values are still stored on the cursor after successful SET.
 SET_VALIDATION_DROP_PARAMETER_KEYS = ("query_label",)
 UPDATE_ENDPOINT_HEADER = "Firebolt-Update-Endpoint"
 UPDATE_PARAMETERS_HEADER = "Firebolt-Update-Parameters"

--- a/src/firebolt/common/constants.py
+++ b/src/firebolt/common/constants.py
@@ -36,6 +36,9 @@ DISALLOWED_PARAMETER_LIST = ["output_format"]
 TRANSACTION_PARAMETER_LIST = [TRANSACTION_ID_SETTING, TRANSACTION_SEQUENCE_ID_SETTING]
 # parameters that are set by the backend and should not be set by the user
 IMMUTABLE_PARAMETER_LIST = USE_PARAMETER_LIST + DISALLOWED_PARAMETER_LIST
+
+# Keys omitted from SET validation probe requests (SELECT 1); values still stored after success
+SET_VALIDATION_DROP_PARAMETER_KEYS = ("query_label",)
 UPDATE_ENDPOINT_HEADER = "Firebolt-Update-Endpoint"
 UPDATE_PARAMETERS_HEADER = "Firebolt-Update-Parameters"
 RESET_SESSION_HEADER = "Firebolt-Reset-Session"

--- a/src/firebolt/db/cursor.py
+++ b/src/firebolt/db/cursor.py
@@ -20,7 +20,11 @@ from httpx import URL, USE_CLIENT_DEFAULT, Response, TimeoutException, codes
 
 from firebolt.client import Client, ClientV1, ClientV2
 from firebolt.common._types import ColType, ParameterType, SetParameter
-from firebolt.common.constants import JSON_OUTPUT_FORMAT, CursorState
+from firebolt.common.constants import (
+    JSON_OUTPUT_FORMAT,
+    SET_VALIDATION_DROP_PARAMETER_KEYS,
+    CursorState,
+)
 from firebolt.common.cursor.base_cursor import (
     BaseCursor,
     _raise_if_internal_set_parameter,
@@ -116,6 +120,7 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         path: str = "",
         use_set_parameters: bool = True,
         timeout: Optional[float] = None,
+        drop_parameter_keys: Optional[Sequence[str]] = None,
     ) -> Response:
         """
         Query API, return Response object.
@@ -132,12 +137,22 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
                 set parameters are sent. Setting this to False will allow
                 self._set_parameters to be ignored.
             timeout (Optional[float]): Request execution timeout in seconds
+            drop_parameter_keys: If non-empty, remove these keys from merged request
+                parameters unless the key appears in this call's ``parameters``
+                dict (the explicit overlay). Empty or omitted is a no-op.
         """
-        parameters = parameters or {}
+        explicit = parameters or {}
         if use_set_parameters:
-            parameters = {**(self._set_parameters or {}), **parameters}
+            parameters = {**(self._set_parameters or {}), **explicit}
+        else:
+            parameters = dict(explicit)
         if self.parameters:
             parameters = {**self.parameters, **parameters}
+        if drop_parameter_keys:
+            explicit_keys = explicit.keys()
+            for k in drop_parameter_keys:
+                if k not in explicit_keys:
+                    parameters.pop(k, None)
         try:
             req = self._client.build_request(
                 url=urljoin(self.engine_url.rstrip("/") + "/", path or ""),
@@ -156,7 +171,10 @@ class Cursor(BaseCursor, metaclass=ABCMeta):
         """Validate parameter by executing simple query with it."""
         _raise_if_internal_set_parameter(parameter)
         resp = self._api_request(
-            "select 1", {parameter.name: parameter.value}, timeout=timeout
+            "select 1",
+            {parameter.name: parameter.value},
+            timeout=timeout,
+            drop_parameter_keys=SET_VALIDATION_DROP_PARAMETER_KEYS,
         )
         # Handle invalid set parameter
         if resp.status_code == codes.BAD_REQUEST:

--- a/tests/unit/async_db/test_cursor.py
+++ b/tests/unit/async_db/test_cursor.py
@@ -523,6 +523,34 @@ async def test_cursor_set_statements(
     assert len(cursor._set_parameters) == 0
 
 
+async def test_validate_set_parameter_drops_inherited_query_label(
+    httpx_mock: HTTPXMock,
+    select_one_query_callback: Callable,
+    set_query_url: str,
+    cursor: Cursor,
+):
+    """Inherited query_label is not sent on SELECT 1 when validating another SET.
+
+    query_label remains stored on the cursor after a subsequent SET.
+    """
+    httpx_mock.add_callback(
+        select_one_query_callback,
+        url=f"{set_query_url}&query_label=v",
+        is_reusable=True,
+    )
+    await cursor.execute("set query_label = v")
+
+    httpx_mock.add_callback(
+        select_one_query_callback,
+        url=f"{set_query_url}&a=b",
+        is_reusable=True,
+    )
+    await cursor.execute("set a = b")
+
+    assert cursor._set_parameters["query_label"] == "v"
+    assert cursor._set_parameters["a"] == "b"
+
+
 async def test_cursor_set_parameters_sent(
     httpx_mock: HTTPXMock,
     set_query_url: str,

--- a/tests/unit/db/test_cursor.py
+++ b/tests/unit/db/test_cursor.py
@@ -509,6 +509,34 @@ def test_cursor_set_statements(
     assert len(cursor._set_parameters) == 0
 
 
+def test_validate_set_parameter_drops_inherited_query_label(
+    httpx_mock: HTTPXMock,
+    select_one_query_callback: Callable,
+    set_query_url: str,
+    cursor: Cursor,
+):
+    """Inherited query_label is not sent on SELECT 1 when validating another SET.
+
+    query_label remains stored on the cursor after a subsequent SET.
+    """
+    httpx_mock.add_callback(
+        select_one_query_callback,
+        url=f"{set_query_url}&query_label=v",
+        is_reusable=True,
+    )
+    cursor.execute("set query_label = v")
+
+    httpx_mock.add_callback(
+        select_one_query_callback,
+        url=f"{set_query_url}&a=b",
+        is_reusable=True,
+    )
+    cursor.execute("set a = b")
+
+    assert cursor._set_parameters["query_label"] == "v"
+    assert cursor._set_parameters["a"] == "b"
+
+
 def test_cursor_set_parameters_sent(
     httpx_mock: HTTPXMock,
     set_query_url: str,


### PR DESCRIPTION
**Description**
SET parameter validation runs a SELECT 1 probe. That probe no longer carries an inherited query_label from earlier SETs, so query history is not polluted by the validation calls when filtering on the query label.

- _api_request accepts optional drop_parameter_keys. When empty/omitted, behavior is unchanged (no extra work on the hot path).
- Non-empty: remove listed keys from merged URL params unless the key is in this call’s explicit parameters overlay.
- _validate_set_parameter passes SET_VALIDATION_DROP_PARAMETER_KEYS (query_label only)
