### PR TITLE
fix: repair broken Sphinx docs deployment to GitHub Pages

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,4 +1,4 @@
-name: Build documenation
+name: Build documentation
 
 on:
   workflow_dispatch:
@@ -68,10 +68,11 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs_compiled
-        destination_dir: sdk_documenation/${{ steps.resolve_url_path.outputs.path }}
+        destination_dir: sdk_documentation/${{ steps.resolve_url_path.outputs.path }}
+        keep_files: true
 
     - name: Add URL to the Job Summary
       shell: bash
       run: |
-        url="https://old.docs.firebolt.io/firebolt-python-sdk/sdk_documenation/${{ steps.resolve_url_path.outputs.path }}"
+        url="https://python.docs.firebolt.io/sdk_documentation/${{ steps.resolve_url_path.outputs.path }}"
         echo "[Documentation]($url)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- **Fixed typo** in `destination_dir`: `sdk_documenation` → `sdk_documentation`, so the deployed path matches the URL linked from [docs.firebolt.io](https://docs.firebolt.io/guides/developing-with-firebolt/connecting-with-python).
- **Added `keep_files: true`** to the `peaceiris/actions-gh-pages` step. Without this, each docs deployment wiped the entire `gh-pages` branch (including Allure reports), and conversely Allure deployments wiped the docs — which is why the `sdk_documenation/` directory no longer exists on `gh-pages` today.
- **Updated summary URL** from the stale `old.docs.firebolt.io` domain to `python.docs.firebolt.io` (the CNAME configured on `gh-pages`).

## Follow-up needed

After merging, trigger the workflow manually (`workflow_dispatch`) or wait for the next release so the docs get deployed. The link on [docs.firebolt.io/guides/developing-with-firebolt/connecting-with-python](https://docs.firebolt.io/guides/developing-with-firebolt/connecting-with-python) also needs updating from `sdk_documenation` to `sdk_documentation` — that lives in the separate docs repo.

## Test plan

- [ ] After merge, trigger `Build documentation` workflow manually from Actions tab
- [ ] Verify `https://python.docs.firebolt.io/sdk_documentation/latest/` returns 200
- [ ] Verify Allure reports at `https://python.docs.firebolt.io/allure/` are still intact


Made with [Cursor](https://cursor.com)