### PR TITLE
fix: correct typo in README docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Documentation
 
-For reference and tutorials, see the [Firebolt Python SDK reference](https://python.docs.firebolt.io/sdk_documenation/latest/).
+For reference and tutorials, see the [Firebolt Python SDK reference](https://python.docs.firebolt.io/sdk_documentation/latest/).
 
 ## Connection parameters
 These parameters are used to connect to a Firebolt database:


### PR DESCRIPTION
## Summary

- Fixes the remaining `sdk_documenation` → `sdk_documentation` typo in `README.md`, matching the deploy path corrected in #516.


Made with [Cursor](https://cursor.com)