### PR TITLE
docs: redirect site root to latest SDK documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Firebolt Python SDK documentation</title>
+    <meta http-equiv="refresh" content="0; url=/sdk_documentation/latest/">
+    <link rel="canonical" href="https://python.docs.firebolt.io/sdk_documentation/latest/">
+  </head>
+  <body>
+    <p>Redirecting to the <a href="/sdk_documentation/latest/">Firebolt Python SDK documentation</a>&hellip;</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a root `index.html` to `gh-pages` that redirects `https://python.docs.firebolt.io/` to `/sdk_documentation/latest/`.
- The site root previously served GitHub's generic 404 page because nothing publishes an index at the branch root; an external security scanner pattern-matched that 404 to a "GitHub Pages takeover" (false positive — the domain is bound to this repo and `docs.firebolt.io` is org-verified). This makes the root URL useful and stops it from tripping such scanners.
- Safe across future deployments: `build-documentation.yml` deploys with `keep_files: true` into `destination_dir: sdk_documentation/…`, so a root file is never overwritten or pruned.

## Test plan

- [ ] After merge, `curl -sI https://python.docs.firebolt.io/` returns 200 with the redirect page (Pages rebuilds on push to `gh-pages`).
- [ ] Browser visit to https://python.docs.firebolt.io/ lands on `/sdk_documentation/latest/`.

Made with [Cursor](https://cursor.com)